### PR TITLE
set --depth to 9999 to ignore user settings, when listing dependencies

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as cp from 'child_process';
 
-const cmd = 'npm list --production --parseable';
+const cmd = 'npm list --production --parseable --depth=99999';
 
 export function getDependencies(cwd: string): Promise<string[]> {
 	return new Promise<string[]>((c, e) => {


### PR DESCRIPTION
The user can set a default value for --depth with:
~~~~~~~~
npm config set depth 0
~~~~~~~~
But we want to ignore this, although `--depth` is ignored when used with `--parseable`.

My original pull request didn't took this into account, because I forgot that @felixfbecker mentioned it in https://github.com/Microsoft/vscode-vsce/issues/52#issuecomment-183679060.