### PR TITLE
Full parity on keywords with MP

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,4 +42,8 @@ gulp.task('watch', ['compile'], function () {
 	gulp.watch(['src/**', 'typings/**'], ['just-compile']);
 });
 
+gulp.task('watch-test', ['compile'], function () {
+	gulp.watch(['src/**', 'typings/**'], ['just-test']);
+});
+
 gulp.task('default', ['watch']);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "vsce": "out/vsce"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "gulp compile && mocha",
     "prepublish": "gulp compile && mocha"
   },
   "engines": {

--- a/src/package.ts
+++ b/src/package.ts
@@ -89,6 +89,12 @@ function getUrl(url: string | { url?: string; }): string {
 	return (<any> url).url;
 }
 
+// Contributed by Mozilla develpoer authors
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+function escapeRegExp(string){
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}
+
 class ManifestProcessor extends BaseProcessor {
 
 	constructor(manifest: Manifest) {
@@ -130,7 +136,7 @@ export class TagsProcessor extends BaseProcessor {
 		'react': ['javascript'],
 		'js': ['javsacript'],
 		'node': ['javascript', 'node'],
-		'C plus plus': ['c++'],
+		'c++': ['c++'],
 		'Cplusplus': ['c++'],
 		'xml': ['xml'],
 		'angular': ['javascript'],
@@ -182,7 +188,7 @@ export class TagsProcessor extends BaseProcessor {
 			const json = contributes && contributes['jsonValidation'] && contributes['jsonValidation'].length > 0 ? ['json'] : [];
 
 			const languageContributions = ((contributes && contributes['languages']) || [])
-				.reduce((r, l) => r.concat([l.id]).concat(l.aliases || []).concat((l.extensions || []).map(e => `$ext_${e}`)), []);
+				.reduce((r, l) => r.concat([l.id]).concat(l.aliases || []).concat((l.extensions || []).map(e => `__ext_${e}`)), []);
 
 			const languageActivations = activationEvents
 				.map(e => /^onLanguage:(.*)$/.exec(e))
@@ -194,7 +200,7 @@ export class TagsProcessor extends BaseProcessor {
 
 			const description = this.manifest.description || '';
 			const descriptionKeywords = Object.keys(TagsProcessor.Keywords)
-				.reduce((r, k) => r.concat(new RegExp(k, 'gi').test(description) ? TagsProcessor.Keywords[k] : []), []);
+				.reduce((r, k) => r.concat(new RegExp('\\b(?:' + escapeRegExp(k) + ')(?!\\w)', 'gi').test(description) ? TagsProcessor.Keywords[k] : []), []);
 
 			keywords = [
 				...keywords,

--- a/src/package.ts
+++ b/src/package.ts
@@ -140,6 +140,7 @@ export class TagsProcessor extends BaseProcessor {
 			const snippets = contributes && contributes['snippets'] && contributes['snippets'].length > 0 ? ['snippet'] : [];
 			const keybindings = contributes && contributes['keybindings'] && contributes['keybindings'].length > 0 ? ['keybindings'] : [];
 			const debuggers = contributes && contributes['debuggers'] && contributes['debuggers'].length > 0 ? ['debuggers'] : [];
+			const json = contributes && contributes['jsonValidation'] && contributes['jsonValidation'].length > 0 ? ['json'] : [];
 
 			const languageContributions = ((contributes && contributes['languages']) || [])
 				.map(l => l.id);
@@ -155,6 +156,7 @@ export class TagsProcessor extends BaseProcessor {
 				...snippets,
 				...keybindings,
 				...debuggers,
+				...json,
 				...languageContributions,
 				...languageActivations
 			];

--- a/src/package.ts
+++ b/src/package.ts
@@ -120,6 +120,45 @@ class ManifestProcessor extends BaseProcessor {
 
 export class TagsProcessor extends BaseProcessor {
 
+	private static Keywords = {
+		'git': ['git'],
+		'npm': ['node'],
+		'spell': ['markdown'],
+		'bootstrap': ['bootstrap'],
+		'lint': ['linters'],
+		'linting': ['linters'],
+		'react': ['javascript'],
+		'js': ['javsacript'],
+		'node': ['javascript', 'node'],
+		'C plus plus': ['c++'],
+		'Cplusplus': ['c++'],
+		'xml': ['xml'],
+		'angular': ['javascript'],
+		'jquery': ['javascript'],
+		'php': ['php'],
+		'python': ['python'],
+		'latex': ['latex'],
+		'ruby': ['ruby'],
+		'java': ['java'],
+		'erlang': ['erlang'],
+		'sql': ['sql'],
+		'nodejs': ['node'],
+		'c#': ['c#'],
+		'css': ['css'],
+		'javascript': ['javascript'],
+		'ftp': ['ftp'],
+		'haskell': ['haskell'],
+		'unity': ['unity'],
+		'terminal': ['terminal'],
+		'powershell': ['powershell'],
+		'laravel': ['laravel'],
+		'meteor': ['meteor'],
+		'emmet': ['emmet'],
+		'eslint': ['linters'],
+		'tfs': ['tfs'],
+		'rust': ['rust']
+	};
+
 	onEnd(): Promise<void> {
 		const keywords = this.manifest.keywords || [];
 		const trimmedKeywords = keywords.slice(0, 5);
@@ -150,6 +189,10 @@ export class TagsProcessor extends BaseProcessor {
 				.filter(r => !!r)
 				.map(r => r[1]);
 
+			const description = this.manifest.description || '';
+			const descriptionKeywords = Object.keys(TagsProcessor.Keywords)
+				.reduce((r, k) => r.concat(new RegExp(k, 'gi').test(description) ? TagsProcessor.Keywords[k] : []), []);
+
 			keywords = [
 				...keywords,
 				...themes,
@@ -158,7 +201,8 @@ export class TagsProcessor extends BaseProcessor {
 				...debuggers,
 				...json,
 				...languageContributions,
-				...languageActivations
+				...languageActivations,
+				...descriptionKeywords
 			];
 
 			this.vsix.tags = _.unique(keywords).join(',');

--- a/src/package.ts
+++ b/src/package.ts
@@ -182,7 +182,7 @@ export class TagsProcessor extends BaseProcessor {
 			const json = contributes && contributes['jsonValidation'] && contributes['jsonValidation'].length > 0 ? ['json'] : [];
 
 			const languageContributions = ((contributes && contributes['languages']) || [])
-				.reduce((r, l) => r.concat([l.id]).concat(l.aliases || []), []);
+				.reduce((r, l) => r.concat([l.id]).concat(l.aliases || []).concat((l.extensions || []).map(e => `$ext_${e}`)), []);
 
 			const languageActivations = activationEvents
 				.map(e => /^onLanguage:(.*)$/.exec(e))

--- a/src/package.ts
+++ b/src/package.ts
@@ -139,6 +139,7 @@ export class TagsProcessor extends BaseProcessor {
 			const themes = contributes && contributes['themes'] && contributes['themes'].length > 0 ? ['theme'] : [];
 			const snippets = contributes && contributes['snippets'] && contributes['snippets'].length > 0 ? ['snippet'] : [];
 			const keybindings = contributes && contributes['keybindings'] && contributes['keybindings'].length > 0 ? ['keybindings'] : [];
+			const debuggers = contributes && contributes['debuggers'] && contributes['debuggers'].length > 0 ? ['debuggers'] : [];
 
 			const languageContributions = ((contributes && contributes['languages']) || [])
 				.map(l => l.id);
@@ -153,6 +154,7 @@ export class TagsProcessor extends BaseProcessor {
 				...themes,
 				...snippets,
 				...keybindings,
+				...debuggers,
 				...languageContributions,
 				...languageActivations
 			];

--- a/src/package.ts
+++ b/src/package.ts
@@ -138,6 +138,7 @@ export class TagsProcessor extends BaseProcessor {
 
 			const themes = contributes && contributes['themes'] && contributes['themes'].length > 0 ? ['theme'] : [];
 			const snippets = contributes && contributes['snippets'] && contributes['snippets'].length > 0 ? ['snippet'] : [];
+			const keybindings = contributes && contributes['keybindings'] && contributes['keybindings'].length > 0 ? ['keybindings'] : [];
 
 			const languageContributions = ((contributes && contributes['languages']) || [])
 				.map(l => l.id);
@@ -151,6 +152,7 @@ export class TagsProcessor extends BaseProcessor {
 				...keywords,
 				...themes,
 				...snippets,
+				...keybindings,
 				...languageContributions,
 				...languageActivations
 			];

--- a/src/package.ts
+++ b/src/package.ts
@@ -182,7 +182,7 @@ export class TagsProcessor extends BaseProcessor {
 			const json = contributes && contributes['jsonValidation'] && contributes['jsonValidation'].length > 0 ? ['json'] : [];
 
 			const languageContributions = ((contributes && contributes['languages']) || [])
-				.map(l => l.id);
+				.reduce((r, l) => r.concat([l.id]).concat(l.aliases || []), []);
 
 			const languageActivations = activationEvents
 				.map(e => /^onLanguage:(.*)$/.exec(e))

--- a/src/package.ts
+++ b/src/package.ts
@@ -189,6 +189,9 @@ export class TagsProcessor extends BaseProcessor {
 				.filter(r => !!r)
 				.map(r => r[1]);
 
+			const grammars = ((contributes && contributes['grammars']) || [])
+				.map(g => g.language);
+
 			const description = this.manifest.description || '';
 			const descriptionKeywords = Object.keys(TagsProcessor.Keywords)
 				.reduce((r, k) => r.concat(new RegExp(k, 'gi').test(description) ? TagsProcessor.Keywords[k] : []), []);
@@ -202,6 +205,7 @@ export class TagsProcessor extends BaseProcessor {
 				...json,
 				...languageContributions,
 				...languageActivations,
+				...grammars,
 				...descriptionKeywords
 			];
 

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -536,7 +536,7 @@ describe('toVsixManifest', () => {
 		return _toVsixManifest(manifest, [])
 			.then(parseXml)
 			.then(result => {
-				const tags = result.PackageManifest.Metadata[0].Tags as string[];
+				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
 				assert(tags.some(tag => tag === 'keybindings'));
 			});
 	});
@@ -561,7 +561,7 @@ describe('toVsixManifest', () => {
 		return _toVsixManifest(manifest, [])
 			.then(parseXml)
 			.then(result => {
-				const tags = result.PackageManifest.Metadata[0].Tags as string[];
+				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
 				assert(tags.some(tag => tag === 'debuggers'));
 			});
 	});
@@ -583,8 +583,27 @@ describe('toVsixManifest', () => {
 		return _toVsixManifest(manifest, [])
 			.then(parseXml)
 			.then(result => {
-				const tags = result.PackageManifest.Metadata[0].Tags as string[];
+				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
 				assert(tags.some(tag => tag === 'json'));
+			});
+	});
+
+	it('should detect keywords in description', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			engines: Object.create(null),
+			description: 'This C plus plus extension likes combines ftp with javascript'
+		};
+
+		return _toVsixManifest(manifest, [])
+			.then(parseXml)
+			.then(result => {
+				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
+				assert(tags.some(tag => tag === 'c++'), 'detect c++');
+				assert(tags.some(tag => tag === 'ftp'), 'detect ftp');
+				assert(tags.some(tag => tag === 'javascript'), 'detect javascript');
 			});
 	});
 });

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -606,6 +606,29 @@ describe('toVsixManifest', () => {
 				assert(tags.some(tag => tag === 'javascript'), 'detect javascript');
 			});
 	});
+
+	it('should detect language grammars', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			engines: Object.create(null),
+			contributes: {
+				grammars: [{
+					language: "shellscript",
+					scopeName: "source.shell",
+					path: "./syntaxes/Shell-Unix-Bash.tmLanguage"
+				}]
+			}
+		};
+
+		return _toVsixManifest(manifest, [])
+			.then(parseXml)
+			.then(result => {
+				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
+				assert(tags.some(tag => tag === 'shellscript'));
+			});
+	});
 });
 
 describe('toContentTypes', () => {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -653,6 +653,29 @@ describe('toVsixManifest', () => {
 				assert(tags.some(tag => tag === 'google-go'));
 			});
 	});
+
+	it('should detect language extensions', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			engines: Object.create(null),
+			contributes: {
+				languages: [{
+					id: 'go',
+					extensions: ['go', 'golang']
+				}]
+			}
+		};
+
+		return _toVsixManifest(manifest, [])
+			.then(parseXml)
+			.then(result => {
+				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
+				assert(tags.some(tag => tag === '$ext_go'));
+				assert(tags.some(tag => tag === '$ext_golang'));
+			});
+	});
 });
 
 describe('toContentTypes', () => {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -540,6 +540,31 @@ describe('toVsixManifest', () => {
 				assert(tags.some(tag => tag === 'keybindings'));
 			});
 	});
+
+	it('should detect debuggers', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			engines: Object.create(null),
+			contributes: {
+				debuggers: [{
+					type: "node",
+					label: "Node Debug",
+					program: "./out/node/nodeDebug.js",
+					runtime: "node",
+					enableBreakpointsFor: { "languageIds": ["javascript", "javascriptreact"] }
+				}]
+			}
+		};
+
+		return _toVsixManifest(manifest, [])
+			.then(parseXml)
+			.then(result => {
+				const tags = result.PackageManifest.Metadata[0].Tags as string[];
+				assert(tags.some(tag => tag === 'debuggers'));
+			});
+	});
 });
 
 describe('toContentTypes', () => {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -519,6 +519,27 @@ describe('toVsixManifest', () => {
 			.then(parseXml)
 			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'theme'));
 	});
+
+	it('should detect keybindings', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			engines: Object.create(null),
+			contributes: {
+				keybindings: [
+					{ command: 'hello', 'key': 'ctrl+f1' }
+				]
+			}
+		};
+
+		return _toVsixManifest(manifest, [])
+			.then(parseXml)
+			.then(result => {
+				const tags = result.PackageManifest.Metadata[0].Tags as string[];
+				assert(tags.some(tag => tag === 'keybindings'));
+			});
+	});
 });
 
 describe('toContentTypes', () => {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -594,7 +594,7 @@ describe('toVsixManifest', () => {
 			publisher: 'mocha',
 			version: '0.0.1',
 			engines: Object.create(null),
-			description: 'This C plus plus extension likes combines ftp with javascript'
+			description: 'This C++ extension likes combines ftp with javascript'
 		};
 
 		return _toVsixManifest(manifest, [])
@@ -604,6 +604,7 @@ describe('toVsixManifest', () => {
 				assert(tags.some(tag => tag === 'c++'), 'detect c++');
 				assert(tags.some(tag => tag === 'ftp'), 'detect ftp');
 				assert(tags.some(tag => tag === 'javascript'), 'detect javascript');
+				assert(!_.contains(tags, 'java'), "don't detect java");
 			});
 	});
 
@@ -672,8 +673,8 @@ describe('toVsixManifest', () => {
 			.then(parseXml)
 			.then(result => {
 				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
-				assert(tags.some(tag => tag === '$ext_go'));
-				assert(tags.some(tag => tag === '$ext_golang'));
+				assert(tags.some(tag => tag === '__ext_go'));
+				assert(tags.some(tag => tag === '__ext_golang'));
 			});
 	});
 });

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -629,6 +629,30 @@ describe('toVsixManifest', () => {
 				assert(tags.some(tag => tag === 'shellscript'));
 			});
 	});
+
+	it('should detect language aliases', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			engines: Object.create(null),
+			contributes: {
+				languages: [{
+					id: 'go',
+					aliases: ['golang', 'google-go']
+				}]
+			}
+		};
+
+		return _toVsixManifest(manifest, [])
+			.then(parseXml)
+			.then(result => {
+				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
+				assert(tags.some(tag => tag === 'go'));
+				assert(tags.some(tag => tag === 'golang'));
+				assert(tags.some(tag => tag === 'google-go'));
+			});
+	});
 });
 
 describe('toContentTypes', () => {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -565,6 +565,28 @@ describe('toVsixManifest', () => {
 				assert(tags.some(tag => tag === 'debuggers'));
 			});
 	});
+
+	it('should detect json validation rules', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			engines: Object.create(null),
+			contributes: {
+				jsonValidation: [{
+					fileMatch: ".jshintrc",
+					url: "http://json.schemastore.org/jshintrc"
+				}]
+			}
+		};
+
+		return _toVsixManifest(manifest, [])
+			.then(parseXml)
+			.then(result => {
+				const tags = result.PackageManifest.Metadata[0].Tags as string[];
+				assert(tags.some(tag => tag === 'json'));
+			});
+	});
 });
 
 describe('toContentTypes', () => {


### PR DESCRIPTION
From @waderyan, #93

MP folks are running an implementation of this pseudocode on the INT database. Once we confirm the data looks good we'll run it on prod. 

We will want to bring full parity with what happens on update for VSCE. The psuedocode is [here](https://github.com/Microsoft/vscode-marketplace/blob/master/tag-seeding-algorithm.js).

Couple things that have evolved since #83. 
- [x] if we detect `contributes.keybindings` tag with `keybindings`
- [x] if we detect `contributes.debuggers` tag with `debuggers`
- [x] if we detect `contributes.jsonValidation` tag with `json`
- [x] use alias to keword map (see [here](https://github.com/Microsoft/vscode-marketplace/blob/master/tag-seeding-algorithm.js#L7)) on description (see [here](https://github.com/Microsoft/vscode-marketplace/blob/master/tag-seeding-algorithm.js#L103))
- [x] if we detect `contributes.grammars.language`, tag with `{ language }`
- [x] if we detect `contributes.languages` then, tag with `{ language.id }`, ` { language.aliases }`, and create hidden keywords for `{ language.extensions }`. Hidden = `$ext_{ language.extensions }`. See [here](https://github.com/Microsoft/vscode-marketplace/blob/master/tag-seeding-algorithm.js#L66). 

My thought is let's wait until MP engineers run this on the INT environment before we make the changes. 

Small update from MP.

- [x] Change hidden tags to '__ext_`{language.extensions}`'
- [x] Make sure we don't have the "java" "javascript" issue