### PR TITLE
Issue 93 change hidden tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "vsce": "out/vsce"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "gulp compile && mocha",
     "prepublish": "gulp compile && mocha"
   },
   "engines": {

--- a/src/package.ts
+++ b/src/package.ts
@@ -130,7 +130,6 @@ export class TagsProcessor extends BaseProcessor {
 		'react': ['javascript'],
 		'js': ['javsacript'],
 		'node': ['javascript', 'node'],
-		'C plus plus': ['c++'],
 		'Cplusplus': ['c++'],
 		'xml': ['xml'],
 		'angular': ['javascript'],
@@ -182,7 +181,7 @@ export class TagsProcessor extends BaseProcessor {
 			const json = contributes && contributes['jsonValidation'] && contributes['jsonValidation'].length > 0 ? ['json'] : [];
 
 			const languageContributions = ((contributes && contributes['languages']) || [])
-				.reduce((r, l) => r.concat([l.id]).concat(l.aliases || []).concat((l.extensions || []).map(e => `$ext_${e}`)), []);
+				.reduce((r, l) => r.concat([l.id]).concat(l.aliases || []).concat((l.extensions || []).map(e => `__ext_${e}`)), []);
 
 			const languageActivations = activationEvents
 				.map(e => /^onLanguage:(.*)$/.exec(e))
@@ -194,7 +193,7 @@ export class TagsProcessor extends BaseProcessor {
 
 			const description = this.manifest.description || '';
 			const descriptionKeywords = Object.keys(TagsProcessor.Keywords)
-				.reduce((r, k) => r.concat(new RegExp(k, 'gi').test(description) ? TagsProcessor.Keywords[k] : []), []);
+				.reduce((r, k) => r.concat(new RegExp('\b' + k + '\b', 'gi').test(description) ? TagsProcessor.Keywords[k] : []), []);
 
 			keywords = [
 				...keywords,

--- a/src/package.ts
+++ b/src/package.ts
@@ -89,6 +89,12 @@ function getUrl(url: string | { url?: string; }): string {
 	return (<any> url).url;
 }
 
+// Contributed by Mozilla develpoer authors
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+function escapeRegExp(string){
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}
+
 class ManifestProcessor extends BaseProcessor {
 
 	constructor(manifest: Manifest) {
@@ -130,6 +136,7 @@ export class TagsProcessor extends BaseProcessor {
 		'react': ['javascript'],
 		'js': ['javsacript'],
 		'node': ['javascript', 'node'],
+		'c++': ['c++'],
 		'Cplusplus': ['c++'],
 		'xml': ['xml'],
 		'angular': ['javascript'],
@@ -193,7 +200,7 @@ export class TagsProcessor extends BaseProcessor {
 
 			const description = this.manifest.description || '';
 			const descriptionKeywords = Object.keys(TagsProcessor.Keywords)
-				.reduce((r, k) => r.concat(new RegExp('\b' + k + '\b', 'gi').test(description) ? TagsProcessor.Keywords[k] : []), []);
+				.reduce((r, k) => r.concat(new RegExp('\\b' + escapeRegExp(k) + '\\b', 'gi').test(description) ? TagsProcessor.Keywords[k] : []), []);
 
 			keywords = [
 				...keywords,

--- a/src/package.ts
+++ b/src/package.ts
@@ -200,7 +200,7 @@ export class TagsProcessor extends BaseProcessor {
 
 			const description = this.manifest.description || '';
 			const descriptionKeywords = Object.keys(TagsProcessor.Keywords)
-				.reduce((r, k) => r.concat(new RegExp('\\b' + escapeRegExp(k) + '\\b', 'gi').test(description) ? TagsProcessor.Keywords[k] : []), []);
+				.reduce((r, k) => r.concat(new RegExp('\\b(?:' + escapeRegExp(k) + ')(?!\\w)', 'gi').test(description) ? TagsProcessor.Keywords[k] : []), []);
 
 			keywords = [
 				...keywords,

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -594,7 +594,7 @@ describe('toVsixManifest', () => {
 			publisher: 'mocha',
 			version: '0.0.1',
 			engines: Object.create(null),
-			description: 'This C plus plus extension likes combines ftp with javascript'
+			description: 'This C++ extension likes combines ftp with javascript'
 		};
 
 		return _toVsixManifest(manifest, [])
@@ -604,6 +604,7 @@ describe('toVsixManifest', () => {
 				assert(tags.some(tag => tag === 'c++'), 'detect c++');
 				assert(tags.some(tag => tag === 'ftp'), 'detect ftp');
 				assert(tags.some(tag => tag === 'javascript'), 'detect javascript');
+				assert(!_.contains(tags, 'java'), "don't detect java");
 			});
 	});
 
@@ -672,8 +673,8 @@ describe('toVsixManifest', () => {
 			.then(parseXml)
 			.then(result => {
 				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
-				assert(tags.some(tag => tag === '$ext_go'));
-				assert(tags.some(tag => tag === '$ext_golang'));
+				assert(tags.some(tag => tag === '__ext_go'));
+				assert(tags.some(tag => tag === '__ext_golang'));
 			});
 	});
 });


### PR DESCRIPTION
@joaomoreno Here are a couple fixes for #94. 

First I changed the hidden tag to be '__' instead of '$'. That was easy. 
The second task I'm having a harder time with and could use your help. An issue we saw with the MP algorithm was javascript extensions being tagged with java. I attempted to fix that by sorounding the regex with '\b' - that solves the "java" issue but introduced a "c++" tagging issue. 

The test is failing now on tagging an extension as "c++". Would love if you could take a look at it. 

Some things I tried. 
- Escaping the regex per instructions [here](http://stackoverflow.com/questions/2593637/how-to-escape-regular-expression-in-javascript) and [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) - because "+" is a regex character. The function from Mozilla didn't seem to work. 