### PR TITLE
Make vsce recognise changelog.md as an asset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsce",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "VSCode Extension Manager",
   "repository": {
     "type": "git",

--- a/src/package.ts
+++ b/src/package.ts
@@ -246,12 +246,12 @@ export class TagsProcessor extends BaseProcessor {
 	}
 }
 
-export class ReadmeProcessor extends BaseProcessor {
+export class MarkdownProcessor extends BaseProcessor {
 
 	private baseContentUrl: string;
 	private baseImagesUrl: string;
 
-	constructor(manifest: Manifest, options: IPackageOptions= {}) {
+	constructor(manifest: Manifest, options: IPackageOptions= {}, private fileRegExp : RegExp) {
 		super(manifest);
 
 		const guess = this.guessBaseUrls();
@@ -263,7 +263,7 @@ export class ReadmeProcessor extends BaseProcessor {
 	onFile(file: IFile): Promise<IFile> {
 		const path = util.normalize(file.path);
 
-		if (!/^extension\/readme.md$/i.test(path)) {
+		if (!this.fileRegExp.test(path)) {
 			return Promise.resolve(file);
 		}
 
@@ -525,7 +525,8 @@ export function createDefaultProcessors(manifest: Manifest, options: IPackageOpt
 	return [
 		new ManifestProcessor(manifest),
 		new TagsProcessor(manifest),
-		new ReadmeProcessor(manifest, options),
+		new MarkdownProcessor(manifest, options, /^extension\/readme.md$/i),
+		new MarkdownProcessor(manifest, options, /^extension\/changelog.md$/i),
 		new LicenseProcessor(manifest),
 		new IconProcessor(manifest)
 	];

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1,5 +1,5 @@
 import {
-	readManifest, collect, toContentTypes, ReadmeProcessor,
+	readManifest, collect, toContentTypes, MarkdownProcessor,
 	read, processFiles, createDefaultProcessors,
 	toVsixManifest, IFile, validateManifest
 } from '../package';
@@ -195,27 +195,29 @@ describe('toVsixManifest', () => {
 			});
 	});
 
-	it('should treat README.md as asset', () => {
-		const manifest = {
-			name: 'test',
-			publisher: 'mocha',
-			version: '0.0.1',
-			description: 'test extension',
-			engines: Object.create(null)
-		};
+	['readme', 'changelog'].forEach((fileType) => {
+		it(`should treat ${fileType.toUpperCase()}.md as asset`, () => {
+			const manifest = {
+				name: 'test',
+				publisher: 'mocha',
+				version: '0.0.1',
+				description: 'test extension',
+				engines: Object.create(null)
+			};
 
-		const files = [
-			{ path: 'extension/readme.md', contents: new Buffer('') }
-		];
+			const files = [
+				{ path: `extension/${fileType}.md`, contents: new Buffer('') }
+			];
 
-		return _toVsixManifest(manifest, files)
-			.then(xml => parseXmlManifest(xml))
-			.then(result => {
-				assert.equal(result.PackageManifest.Assets[0].Asset.length, 2);
-				assert.equal(result.PackageManifest.Assets[0].Asset[1].$.Type, 'Microsoft.VisualStudio.Services.Content.Details');
-				assert.equal(result.PackageManifest.Assets[0].Asset[1].$.Path, 'extension/readme.md');
-			});
-	});
+			return _toVsixManifest(manifest, files)
+				.then(xml => parseXmlManifest(xml))
+				.then(result => {
+					assert.equal(result.PackageManifest.Assets[0].Asset.length, 2);
+					assert.equal(result.PackageManifest.Assets[0].Asset[1].$.Type, 'Microsoft.VisualStudio.Services.Content.Details');
+					assert.equal(result.PackageManifest.Assets[0].Asset[1].$.Path, `extension/${fileType}.md`);
+				});
+		});
+	})
 
 	it('should respect display name', () => {
 		const manifest = {
@@ -1001,7 +1003,7 @@ describe('toContentTypes', () => {
 	});
 });
 
-describe('ReadmeProcessor', () => {
+describe('MarkdownProcessor', () => {
 
 	it('should be no-op when no baseContentUrl is provided', () => {
 		const manifest = {
@@ -1013,7 +1015,7 @@ describe('ReadmeProcessor', () => {
 		};
 
 		const root = fixture('readme');
-		const processor = new ReadmeProcessor(manifest);
+		const processor = new MarkdownProcessor(manifest, {}, /^extension\/readme.md$/i);
 		const readme = {
 			path: 'extension/readme.md',
 			localPath: path.join(root, 'readme.md')
@@ -1039,10 +1041,10 @@ describe('ReadmeProcessor', () => {
 		};
 
 		const root = fixture('readme');
-		const processor = new ReadmeProcessor(manifest, {
+		const processor = new MarkdownProcessor(manifest, {
 			baseContentUrl: 'https://github.com/username/repository/blob/master',
 			baseImagesUrl: 'https://github.com/username/repository/raw/master'
-		});
+		}, /^extension\/readme.md$/i);
 		const readme = {
 			path: 'extension/readme.md',
 			localPath: path.join(root, 'readme.md')
@@ -1069,7 +1071,7 @@ describe('ReadmeProcessor', () => {
 		};
 
 		const root = fixture('readme');
-		const processor = new ReadmeProcessor(manifest);
+		const processor = new MarkdownProcessor(manifest, {}, /^extension\/readme.md$/i);
 		const readme = {
 			path: 'extension/readme.md',
 			localPath: path.join(root, 'readme.md')
@@ -1096,7 +1098,7 @@ describe('ReadmeProcessor', () => {
 		};
 
 		const root = fixture('readme');
-		const processor = new ReadmeProcessor(manifest);
+		const processor = new MarkdownProcessor(manifest, {}, /^extension\/readme.md$/i);
 		const readme = {
 			path: 'extension/readme.md',
 			localPath: path.join(root, 'readme.md')
@@ -1127,7 +1129,7 @@ describe('ReadmeProcessor', () => {
 		};
 
 		const root = fixture('readme');
-		const processor = new ReadmeProcessor(manifest, options);
+		const processor = new MarkdownProcessor(manifest, options, /^extension\/readme.md$/i);
 		const readme = {
 			path: 'extension/readme.md',
 			localPath: path.join(root, 'readme.md')


### PR DESCRIPTION
The following PR will address #126 that is - if a changelog file is present in your directory, it will make sure to treat it as an asset (which can be used around the ecosystem).

Notes are in the code!