### PR TITLE
check for enableProposedApi and don't allow to publish

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -22,6 +22,7 @@ export interface Manifest {
 	markdown?: 'github' | 'standard';
 	_bundling?: { [name: string]: string; }[];
 	_testing?: string;
+	enableProposedApi?: boolean;
 
 	// optional (npm)
 	author?: string | Person;

--- a/src/package.ts
+++ b/src/package.ts
@@ -432,6 +432,10 @@ export function validateManifest(manifest: Manifest): Manifest {
 		throw new Error('Manifest missing field: engines.vscode');
 	}
 
+	if (manifest.enableProposedApi) {
+		throw new Error('Extensions using proposed API (enableProposedApi: true) cannot be published');
+	}
+
 	return manifest;
 }
 
@@ -471,7 +475,7 @@ export function writeManifest(cwd: string, manifest: Manifest): Promise<void> {
 }
 
 export function toVsixManifest(assets: IAsset[], vsix: any, options: IPackageOptions = {}): Promise<string> {
-		return readFile(vsixManifestTemplatePath, 'utf8')
+	return readFile(vsixManifestTemplatePath, 'utf8')
 		.then(vsixManifestTemplateStr => _.template(vsixManifestTemplateStr))
 		.then(vsixManifestTemplate => vsixManifestTemplate(vsix));
 }

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -147,6 +147,17 @@ describe('validateManifest', () => {
 		assert.throws(() => { validateManifest({ publisher: 'demo', name: 'demo', version: '1.0.0', engines: null }); });
 		assert.throws(() => { validateManifest({ publisher: 'demo', name: 'demo', version: '1.0.0', engines: { vscode: null } }); });
 	});
+
+	it('should not allow proposed API', () => {
+		assert.throws(() => { validateManifest({ enableProposedApi: true, publisher: 'demo', name: 'demo', version: '1.0.0', engines: { vscode: '0.10.1' } }); });
+		assert.throws(() => { validateManifest({ enableProposedApi: <any>1, publisher: 'demo', name: 'demo', version: '1.0.0', engines: { vscode: '0.10.1' } }); });
+
+		let mani1: Manifest = { enableProposedApi: false, publisher: 'demo', name: 'demo', version: '1.0.0', engines: { vscode: '0.10.1' } };
+		assert.ok(validateManifest(mani1) === mani1);
+
+		let mani2: Manifest = { publisher: 'demo', name: 'demo', version: '1.0.0', engines: { vscode: '0.10.1' } };
+		assert.ok(validateManifest(mani2) === mani2);
+	});
 });
 
 describe('toVsixManifest', () => {


### PR DESCRIPTION
We want to be defensive when it comes to proposed API and one part of this is to not allow extensions to be published unless `enableProposedApi` is off.