### PR TITLE
Fix manifest overriding

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -442,7 +442,7 @@ export function validateManifest(manifest: Manifest): Manifest {
 	return manifest;
 }
 
-export function readManifest(cwd = process.cwd()): Promise<Manifest> {
+export function readManifest(cwd = process.cwd(), nls = true): Promise<Manifest> {
 	const manifestPath = path.join(cwd, 'package.json');
 	const manifestNLSPath = path.join(cwd, 'package.nls.json');
 
@@ -457,19 +457,23 @@ export function readManifest(cwd = process.cwd()): Promise<Manifest> {
 		})
 		.then(validateManifest);
 
-	const manifestNLS = readFile(manifestNLSPath, 'utf8')
-		.catch<string>(err => err.code !== 'ENOENT' ? Promise.reject(err) : Promise.resolve('{}'))
-		.then<ITranslations>(raw => {
-			try {
-				return Promise.resolve(JSON.parse(raw));
-			} catch (e) {
-				return Promise.reject(`Error parsing manifest translations file: not a valid JSON file.`);
-			}
-		});
+	if (nls) {
+		const manifestNLS = readFile(manifestNLSPath, 'utf8')
+			.catch<string>(err => err.code !== 'ENOENT' ? Promise.reject(err) : Promise.resolve('{}'))
+			.then<ITranslations>(raw => {
+				try {
+					return Promise.resolve(JSON.parse(raw));
+				} catch (e) {
+					return Promise.reject(`Error parsing manifest translations file: not a valid JSON file.`);
+				}
+			});
 
-	return Promise.all([manifest, manifestNLS]).then(([manifest, translations]) => {
-		return patchNLS(manifest, translations);
-	});
+		return Promise.all([manifest, manifestNLS]).then(([manifest, translations]) => {
+			return patchNLS(manifest, translations);
+		});
+	} else {
+		return manifest;
+	}
 }
 
 export function writeManifest(cwd: string, manifest: Manifest): Promise<void> {

--- a/src/package.ts
+++ b/src/package.ts
@@ -457,23 +457,22 @@ export function readManifest(cwd = process.cwd(), nls = true): Promise<Manifest>
 		})
 		.then(validateManifest);
 
-	if (nls) {
-		const manifestNLS = readFile(manifestNLSPath, 'utf8')
-			.catch<string>(err => err.code !== 'ENOENT' ? Promise.reject(err) : Promise.resolve('{}'))
-			.then<ITranslations>(raw => {
-				try {
-					return Promise.resolve(JSON.parse(raw));
-				} catch (e) {
-					return Promise.reject(`Error parsing manifest translations file: not a valid JSON file.`);
-				}
-			});
+	if (!nls) return manifest;
 
-		return Promise.all([manifest, manifestNLS]).then(([manifest, translations]) => {
-			return patchNLS(manifest, translations);
+	const manifestNLS = readFile(manifestNLSPath, 'utf8')
+		.catch<string>(err => err.code !== 'ENOENT' ? Promise.reject(err) : Promise.resolve('{}'))
+		.then<ITranslations>(raw => {
+			try {
+				return Promise.resolve(JSON.parse(raw));
+			} catch (e) {
+				return Promise.reject(`Error parsing manifest translations file: not a valid JSON file.`);
+			}
 		});
-	} else {
-		return manifest;
-	}
+
+	return Promise.all([manifest, manifestNLS]).then(([manifest, translations]) => {
+		return patchNLS(manifest, translations);
+	});
+
 }
 
 export function writeManifest(cwd: string, manifest: Manifest): Promise<void> {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -90,7 +90,7 @@ function versionBump(cwd: string = process.cwd(), version?: string): Promise<voi
 		return Promise.resolve(null);
 	}
 
-	return readManifest(cwd)
+	return readManifest(cwd, false)
 		.then(manifest => {
 			switch (version) {
 				case 'major':

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -135,6 +135,19 @@ describe('readManifest', () => {
 				assert.equal(manifest.contributes.debuggers[0].label, translations['node.label']);
 			});
 	});
+
+	it('should not patch NLS if required', () => {
+		const cwd = fixture('nls');
+		const raw = require('./fixtures/nls/package.json');
+		const translations = require('./fixtures/nls/package.nls.json');
+
+		return readManifest(cwd, false)
+			.then((manifest: any) => {
+				assert.equal(manifest.name, raw.name);
+				assert.notEqual(manifest.description, translations['extension.description']);
+				assert.notEqual(manifest.contributes.debuggers[0].label, translations['node.label']);
+			});
+	});
 });
 
 describe('validateManifest', () => {


### PR DESCRIPTION
Fixes #158 

I've prepared a PR with maybe a naive implementation. Let me know if that works. The idea is to provide an option for the readManifest function to only read the manifest without applying the translation parsing. Then in the versionBump we're using this to do the overwriting without issues.