### PR TITLE
Add www.versioneye.com to trusted SVG sources

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -127,7 +127,8 @@ const TrustedSVGSources = [
 	'badges.frapsoft.com',
 	'cdn.travis-ci.org',
 	'marketplace.visualstudio.com',
-	'ci.appveyor.com'
+	'ci.appveyor.com',
+	'www.versioneye.com'
 ];
 
 function isHostTrusted(host: string): boolean {


### PR DESCRIPTION
I think [VersionEye](http://www.versioneye.com) should be a trusted source, this service allows easy dependency checking and can prevent security vulnerabilities from creeping in javascript based projects, which means it could easily be used by any VSCode extension that has some code in it.