### PR TITLE
Fixed javascript typo

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -199,7 +199,7 @@ export class TagsProcessor extends BaseProcessor {
 		'lint': ['linters'],
 		'linting': ['linters'],
 		'react': ['javascript'],
-		'js': ['javsacript'],
+		'js': ['javascript'],
 		'node': ['javascript', 'node'],
 		'c++': ['c++'],
 		'Cplusplus': ['c++'],


### PR DESCRIPTION
A lot of extensions are published with the keyword `javsacript`  and I think this is the reason why.