### PR TITLE
[Added] Relative sources in <img> tags in README.md are not rewritten to absolute URLs

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -363,8 +363,7 @@ export class MarkdownProcessor extends BaseProcessor {
 				return all;
 			}
 
-			let returnvalue = all.replace(link, urljoin(prefix, link));
-			return returnvalue;
+			return all.replace(link, urljoin(prefix, link));
 		};
 
 		contents = contents.replace(markdownPathRegex, urlReplace);

--- a/src/test/fixtures/readme/readme.expected.md
+++ b/src/test/fixtures/readme/readme.expected.md
@@ -20,6 +20,7 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 
 [![Jump to issues](https://github.com/username/repository/raw/master/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
 [![Jump to issues](https://github.com/username/repository/raw/master/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/master/monkey)
+<img src="https://github.com/username/repository/raw/master/images/myImage.gif">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.images.expected.md
+++ b/src/test/fixtures/readme/readme.images.expected.md
@@ -20,6 +20,7 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 
 [![Jump to issues](https://github.com/username/repository/path/to/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
 [![Jump to issues](https://github.com/username/repository/path/to/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/master/monkey)
+<img src="https://github.com/username/repository/path/to/images/myImage.gif">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.md
+++ b/src/test/fixtures/readme/readme.md
@@ -20,6 +20,7 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 
 [![Jump to issues](images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
 [![Jump to issues](images/SpellMDDemo2.gif)](monkey)
+<img src="/images/myImage.gif">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 


### PR DESCRIPTION
On Issue Request #192 

Please review the changes. If anything is wrong please guide me. [I'm a newbie]