### PR TITLE
Feature/issue 214 add show command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as program from 'commander';
 import { packageCommand, ls } from './package';
 import { publish, list, unpublish } from './publish';
+import { show } from './show';
 import { listPublishers, createPublisher, deletePublisher, loginPublisher, logoutPublisher } from './store';
 import { getLatestVersion } from './npm';
 import { CancellationToken, isCancelledError } from './util';
@@ -111,6 +112,12 @@ module.exports = function (argv: string[]): void {
 		.command('logout <publisher>')
 		.description('Remove a publisher from the known publishers list')
 		.action(name => main(logoutPublisher(name)));
+
+	program
+		.command('show <extensionIdentifier>')
+		.option('--json', 'Output data in json format', false)
+		.description('Show extension metadata')
+		.action((extensionIdentifier, { json }) => main(show(extensionIdentifier, json)));
 
 	program
 		.command('*')

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,10 +114,10 @@ module.exports = function (argv: string[]): void {
 		.action(name => main(logoutPublisher(name)));
 
 	program
-		.command('show <extensionIdentifier>')
+		.command('show <extensionid>')
 		.option('--json', 'Output data in json format', false)
 		.description('Show extension metadata')
-		.action((extensionIdentifier, { json }) => main(show(extensionIdentifier, json)));
+		.action((extensionid, { json }) => main(show(extensionid, json)));
 
 	program
 		.command('*')

--- a/src/publicgalleryapi.ts
+++ b/src/publicgalleryapi.ts
@@ -1,0 +1,61 @@
+import { HttpClient, HttpClientResponse } from 'vso-node-api/HttpClient';
+import { PublishedExtension, ExtensionQueryFlags, FilterCriteria, SortOrderType, SortByType, ExtensionQueryFilterType } from 'vso-node-api/interfaces/GalleryInterfaces';
+import { IHeaders } from 'vso-node-api/interfaces/common/VsoBaseInterfaces';
+
+export interface ExtensionQuery {
+	pageNumber?: number;
+	pageSize?: number;
+	sortBy?: SortByType;
+	sortOrder?: SortOrderType;
+	flags?: ExtensionQueryFlags[];
+	criteria?: FilterCriteria[];
+	assetTypes?: string[];
+}
+
+function filterByExtensionId(extensionId) {
+	return ({publisher: {publisherName}, extensionName}) => extensionId === `${publisherName}.${extensionName}`;
+}
+
+export class PublicGalleryAPI {
+	client: HttpClient;
+
+	constructor(public baseUrl: string, public apiVersion = '3.0-preview.1') {
+		this.client = new HttpClient('vsce');
+	}
+
+	post(url: string, data: string, additionalHeaders?: IHeaders): Promise<HttpClientResponse> {
+		return this.client.post(`${this.baseUrl}/_apis/public/${url}`, data, additionalHeaders);
+	}
+
+	extensionQuery({
+		pageNumber = 1,
+		pageSize = 1,
+		sortBy = SortByType.Relevance,
+		sortOrder = SortOrderType.Default,
+		flags = [],
+		criteria = [],
+		assetTypes = [],
+	}: ExtensionQuery): Promise<PublishedExtension[]> {
+		return this.post('/gallery/extensionquery', JSON.stringify({
+			filters: [{pageNumber, pageSize, criteria}],
+			assetTypes,
+			flags: flags.reduce((memo, flag) => memo | flag, 0)
+		}), {
+			Accept: `application/json;api-version=${this.apiVersion}`,
+			'Content-Type': 'application/json',
+		})
+			.then(res => res.readBody())
+			.then(data => JSON.parse(data))
+			.then(({results: [result = {}] = []}) => result)
+			.then(({extensions = []}) => <PublishedExtension[]>extensions);
+	}
+
+	getExtension(extensionId: string, flags: ExtensionQueryFlags[] = []): Promise<PublishedExtension> {
+		return this.extensionQuery({
+			criteria: [{ filterType: ExtensionQueryFilterType.Name, value: extensionId }],
+			flags,
+		})
+		.then(result => result.filter(filterByExtensionId(extensionId)))
+		.then(([extension]) => extension);
+	}
+}

--- a/src/publicgalleryapi.ts
+++ b/src/publicgalleryapi.ts
@@ -22,7 +22,7 @@ export class PublicGalleryAPI {
 	}
 
 	post(url: string, data: string, additionalHeaders?: IHeaders): Promise<HttpClientResponse> {
-		return this.client.post(`${this.baseUrl}/_apis/public/${url}`, data, additionalHeaders);
+		return this.client.post(`${this.baseUrl}/_apis/public${url}`, data, additionalHeaders);
 	}
 
 	extensionQuery({

--- a/src/show.ts
+++ b/src/show.ts
@@ -72,7 +72,6 @@ const indentRow = (row: string) => `  ${row}`;
 
 function showOverview({
 	displayName,
-	extensionId,
 	extensionName,
 	shortDescription,
 	versions,
@@ -126,7 +125,6 @@ function showOverview({
 			[ 'Last updated:', lastUpdated.toLocaleString(fixedLocale, formatDateTime) ],
 			[ 'Publisher:', publisherDisplayName ],
 			[ 'Published at:', publishedDate.toLocaleString(fixedLocale, formatDate) ],
-			[ 'Extension-ID:', extensionId ],
 		])
 			.map(indentRow),
 		'',

--- a/src/show.ts
+++ b/src/show.ts
@@ -10,8 +10,9 @@ export interface ExtensionStatiticsMap {
 export type ViewTableRow = string[];
 export type ViewTable = ViewTableRow[];
 
-export function show(extensionUniqIdentifier: string, json: boolean = false): Promise<any> {
-	const [extensionPublisher, extensionName] = extensionUniqIdentifier.split(/\.(.+)?/, 2);
+export function show(extensionid: string, json: boolean = false): Promise<any> {
+	const [extensionPublisher, ...extensionNameParts] = extensionid.split('.');
+	const extensionName = extensionNameParts.join('.');
 	const flags =
 		ExtensionQueryFlags.IncludeCategoryAndTags |
 		ExtensionQueryFlags.IncludeMetadata |

--- a/src/show.ts
+++ b/src/show.ts
@@ -116,7 +116,7 @@ function showOverview({
 		'',
 		'More info:',
 		...tableView([
-			[ 'Uniq identifier:', `${extensionName}.${publisherName}` ],
+			[ 'Uniq identifier:', `${publisherName}.${extensionName}` ],
 			[ 'Version:', version ],
 			[ 'Last updated:', lastUpdated.toLocaleString(fixedLocale, formatDateTime) ],
 			[ 'Publisher:', publisherDisplayName ],

--- a/src/show.ts
+++ b/src/show.ts
@@ -57,13 +57,17 @@ function tableView(table: ViewTable, spacing: number = 2): string[] {
 }
 
 function wordWrap(text: string, width: number = 80): string {
+	const [indent = ''] = text.match(/^\s+/) || [];
+	const maxWidth = width - indent.length;
 	return text
+		.replace(/^\s+/, '')
 		.split('')
 		.reduce(([out, buffer, pos], ch, i) => {
-			const nl = pos === width ? '\n' : '';
+			const nl = pos === maxWidth ? `\n${indent}` : '';
 			const newPos: number = nl ? 0 : +pos + 1;
-			return ch === ' ' ? [`${out}${buffer} ${nl}`, '', newPos] : [`${out}${nl}`, buffer+ch, newPos];
-		}, ['', '', 0])
+			return / |-|,|\./.test(ch) ?
+				[`${out}${buffer}${ch}${nl}`, '', newPos] : [`${out}${nl}`, buffer+ch, newPos];
+		}, [indent, '', 0])
 		.slice(0, 2)
 		.join('');
 };

--- a/src/show.ts
+++ b/src/show.ts
@@ -1,0 +1,134 @@
+import { getExtension } from './store';
+import { ExtensionQueryFlags, PublishedExtension } from 'vso-node-api/interfaces/GalleryInterfaces';
+
+export interface ExtensionStatiticsMap {
+	install: number;
+	averagerating: number;
+	ratingcount:number;
+}
+
+export type ViewTableRow = string[];
+export type ViewTable = ViewTableRow[];
+
+export function show(extensionUniqIdentifier: string, json: boolean = false): Promise<any> {
+	const [extensionPublisher, extensionName] = extensionUniqIdentifier.split(/\.(.+)?/, 2);
+	const flags =
+		ExtensionQueryFlags.IncludeCategoryAndTags |
+		ExtensionQueryFlags.IncludeMetadata |
+		ExtensionQueryFlags.IncludeStatistics |
+		ExtensionQueryFlags.IncludeVersions;
+	return getExtension(extensionPublisher, extensionName, undefined, flags)
+		.then(extension => {
+			if (json) {
+				console.log(JSON.stringify(extension, undefined, '\t'));
+			} else {
+				showOverview(extension);
+			}
+		});
+}
+
+const fixedLocale = 'en-us';
+const formatDate = { month: 'long', day: 'numeric', year: 'numeric' };
+const formatTime = { hour: 'numeric', minute: 'numeric', second: 'numeric' };
+const formatDateTime = { ...formatDate, ...formatTime };
+
+function repeatString(text: string, count: number): string {
+	let result: string = '';
+	for (let i = 0; i < count; i++) {
+		result += text;
+	}
+	return result;
+}
+
+function ratingStars(rating: number): string {
+	const c = Math.min(Math.round(rating), 5);
+	return `${repeatString('\u{2605} ', c)}${repeatString('\u{2606} ', 5 - c)}`;
+}
+
+function tableView(table: ViewTable, spacing: number = 2): string[] {
+	const maxLen = {};
+	table.forEach(row => row.forEach((cell, i) => maxLen[i] = Math.max(maxLen[i] || 0, cell.length)));
+	return table.map(row => row.map((cell, i) => `${cell}${repeatString(' ', maxLen[i] - cell.length + spacing)}`).join(''));
+}
+
+function wordWrap(text: string, width: number = 80): string {
+	return text
+		.split('')
+		.reduce(([out, buffer, pos], ch, i) => {
+			const nl = pos === width ? '\n' : '';
+			const newPos: number = nl ? 0 : +pos + 1;
+			return ch === ' ' ? [`${out}${buffer} ${nl}`, '', newPos] : [`${out}${nl}`, buffer+ch, newPos];
+		}, ['', '', 0])
+		.slice(0, 2)
+		.join('');
+};
+
+const indentRow = (row: string) => `  ${row}`;
+
+function showOverview({
+	displayName,
+	extensionId,
+	extensionName,
+	shortDescription,
+	versions,
+	publisher: {
+		displayName:publisherDisplayName,
+		publisherName
+	},
+	categories,
+	tags,
+	statistics,
+	publishedDate,
+	lastUpdated,
+}: PublishedExtension) {
+
+	const [{ version = 'unknown' } = {}] = versions;
+
+	// Create formatted table list of versions
+	const versionList = <ViewTable>versions
+		.slice(0, 6)
+		.map(({version, lastUpdated}) => [version, lastUpdated.toLocaleString(fixedLocale, formatDate)]);
+
+	const {
+		install: installs = 0,
+		averagerating = 0,
+		ratingcount = 0,
+	} = statistics
+		.reduce((map, {statisticName, value}) => ({ ...map, [statisticName]: value }), <ExtensionStatiticsMap>{});
+
+	// Render
+	console.log([
+		`${displayName}`,
+		`${publisherDisplayName} | ${'\u2913'}` +
+		`${Number(installs).toLocaleString()} installs |` +
+		` ${ratingStars(averagerating)} (${ratingcount})`,
+		'',
+		`${shortDescription}`,
+		'',
+		'Recent versions:',
+		...(versionList.length ? tableView(versionList).map(indentRow) : ['no versions found']),
+		'',
+		'Categories:',
+		`  ${categories.join(', ')}`,
+		'',
+		'Tags:',
+		`  ${tags.join(', ')}`,
+		'',
+		'More info:',
+		...tableView([
+			[ 'Uniq identifier:', `${extensionName}.${publisherName}` ],
+			[ 'Version:', version ],
+			[ 'Last updated:', lastUpdated.toLocaleString(fixedLocale, formatDateTime) ],
+			[ 'Publisher:', publisherDisplayName ],
+			[ 'Published at:', publishedDate.toLocaleString(fixedLocale, formatDate) ],
+			[ 'Extension-ID:', extensionId ],
+		])
+			.map(indentRow),
+		'',
+		'Statistics:',
+		...tableView(<ViewTable>statistics.map(({statisticName, value}) => [statisticName, Number(value).toFixed(2)]))
+			.map(indentRow),
+	]
+		.map(line => wordWrap(line))
+		.join('\n'));
+}

--- a/src/show.ts
+++ b/src/show.ts
@@ -1,4 +1,4 @@
-import { getExtension } from './store';
+import { getPublicGalleryAPI } from './util';
 import { ExtensionQueryFlags, PublishedExtension } from 'vso-node-api/interfaces/GalleryInterfaces';
 
 export interface ExtensionStatiticsMap {
@@ -10,21 +10,21 @@ export interface ExtensionStatiticsMap {
 export type ViewTableRow = string[];
 export type ViewTable = ViewTableRow[];
 
-export function show(extensionid: string, json: boolean = false): Promise<any> {
-	const [extensionPublisher, ...extensionNameParts] = extensionid.split('.');
-	const extensionName = extensionNameParts.join('.');
-	const flags =
-		ExtensionQueryFlags.IncludeCategoryAndTags |
-		ExtensionQueryFlags.IncludeMetadata |
-		ExtensionQueryFlags.IncludeStatistics |
-		ExtensionQueryFlags.IncludeVersions;
-	return getExtension(extensionPublisher, extensionName, undefined, flags)
+export function show(extensionId: string, json: boolean = false): Promise<any> {
+	const flags = [
+		ExtensionQueryFlags.IncludeCategoryAndTags,
+		ExtensionQueryFlags.IncludeMetadata,
+		ExtensionQueryFlags.IncludeStatistics,
+		ExtensionQueryFlags.IncludeVersions,
+	];
+	return getPublicGalleryAPI()
+		.getExtension(extensionId, flags)
 		.then(extension => {
 			if (json) {
 				console.log(JSON.stringify(extension, undefined, '\t'));
 			} else {
 				if (extension === undefined) {
-					console.log(`Error: Extension "${extensionName}" by ${extensionPublisher} not found.`);
+					console.log(`Error: Extension "${extensionId}" not found.`);
 				} else {
 					showOverview(extension);
 				}

--- a/src/show.ts
+++ b/src/show.ts
@@ -23,7 +23,11 @@ export function show(extensionid: string, json: boolean = false): Promise<any> {
 			if (json) {
 				console.log(JSON.stringify(extension, undefined, '\t'));
 			} else {
-				showOverview(extension);
+				if (extension === undefined) {
+					console.log(`Error: Extension "${extensionName}" by ${extensionPublisher} not found.`);
+				} else {
+					showOverview(extension);
+				}
 			}
 		});
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -171,12 +171,25 @@ export function getExtension(
 	accountToken?: string
 ): Promise<PublishedExtension> {
 	return load()
-	.then(({publishers}) => { // xxx: use any token available it's a read op
-		if (!publishers || !publishers.length) {
-			throw new Error(`Login is required.`);
-		}
-		return publishers;
-	})
-	.then(([{pat}]) => getGalleryAPI(pat))
-	.then(api => api.getExtension(extensionPublisher, extensionName, version, flags, accountToken));
+		.then(async ({publishers}) => { // xxx: use any token available it's a read op
+			if (!publishers || !publishers.length) {
+				throw new Error(`Login is required.`);
+			}
+			// Use one of the access tokens in store (one that works)
+			for (let i = 0; i < publishers.length; i++) {
+				const {pat} = publishers[i];
+				try {
+					return await getGalleryAPI(pat).getExtension(extensionPublisher, extensionName, version, flags, accountToken);
+				} catch (err) {
+					// xxx: If access token is invalid we get "Invalid Resource"
+					if (/Invalid Resource/.test(err.message)) {
+						if (i === publishers.length - 1) {
+							throw new Error(`${err.message} (check if access token has expired).`);
+						}
+					} else {
+						throw err;
+					}
+				}
+			}
+		});
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -171,7 +171,12 @@ export function getExtension(
 	accountToken?: string
 ): Promise<PublishedExtension> {
 	return load()
-	.then(({publishers}) => publishers[0]) // xxx: use any token available it's a read op
-	.then(({pat}) => getGalleryAPI(pat))
+	.then(({publishers}) => { // xxx: use any token available it's a read op
+		if (!publishers || !publishers.length) {
+			throw new Error(`Login is required.`);
+		}
+		return publishers;
+	})
+	.then(([{pat}]) => getGalleryAPI(pat))
 	.then(api => api.getExtension(extensionPublisher, extensionName, version, flags, accountToken));
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,6 +4,7 @@ import { home } from 'osenv';
 import { read, getGalleryAPI } from './util';
 import { validatePublisher } from './validation';
 import * as denodeify from 'denodeify';
+import { PublishedExtension, ExtensionQueryFlags } from 'vso-node-api/interfaces/GalleryInterfaces';
 
 const readFile = denodeify<string, string, string>(fs.readFile);
 const writeFile = denodeify<string, string, void>(fs.writeFile as any);
@@ -160,4 +161,17 @@ export function listPublishers(): Promise<void> {
 	return load()
 		.then(store => store.publishers)
 		.then(publishers => publishers.forEach(p => console.log(p.name)));
+}
+
+export function getExtension(
+	extensionPublisher: string,
+	extensionName: string,
+	version?: string,
+	flags?: ExtensionQueryFlags,
+	accountToken?: string
+): Promise<PublishedExtension> {
+	return load()
+	.then(({publishers}) => publishers[0]) // xxx: use any token available it's a read op
+	.then(({pat}) => getGalleryAPI(pat))
+	.then(api => api.getExtension(extensionPublisher, extensionName, version, flags, accountToken));
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,7 @@ import * as _read from 'read';
 import { WebApi, getBasicHandler } from 'vso-node-api/WebApi';
 import { IGalleryApi } from 'vso-node-api/GalleryApi';
 import * as denodeify from 'denodeify';
+import { PublicGalleryAPI } from './publicgalleryapi';
 
 const __read = denodeify<_read.Options, string>(_read);
 export function read(prompt: string, options: _read.Options = {}): Promise<string> {
@@ -12,6 +13,10 @@ export function getGalleryAPI(pat: string): IGalleryApi {
 	const authHandler = getBasicHandler('oauth', pat);
 	const vsoapi = new WebApi('oauth', authHandler);
 	return vsoapi.getGalleryApi('https://marketplace.visualstudio.com');
+}
+
+export function getPublicGalleryAPI() {
+	return new PublicGalleryAPI('https://marketplace.visualstudio.com', '3.0-preview.1');
 }
 
 export function normalize(path: string): string {

--- a/src/viewutils.ts
+++ b/src/viewutils.ts
@@ -1,0 +1,49 @@
+export type ViewTableRow = string[];
+export type ViewTable = ViewTableRow[];
+
+const fixedLocale = 'en-us';
+const format = {
+	date: { month: 'long', day: 'numeric', year: 'numeric' },
+	time: { hour: 'numeric', minute: 'numeric', second: 'numeric' },
+};
+
+export function formatDate(date) { return date.toLocaleString(fixedLocale, format.date); }
+export function formatTime(date) { return date.toLocaleString(fixedLocale, format.time); }
+export function formatDateTime(date) { return date.toLocaleString(fixedLocale, { ...format.date, ...format.time }); }
+
+export function repeatString(text: string, count: number): string {
+	let result: string = '';
+	for (let i = 0; i < count; i++) {
+		result += text;
+	}
+	return result;
+}
+
+export function ratingStars(rating: number, total = 5): string {
+	const c = Math.min(Math.round(rating), total);
+	return `${repeatString('\u{2605} ', c)}${repeatString('\u{2606} ', total - c)}`;
+}
+
+export function tableView(table: ViewTable, spacing: number = 2): string[] {
+	const maxLen = {};
+	table.forEach(row => row.forEach((cell, i) => maxLen[i] = Math.max(maxLen[i] || 0, cell.length)));
+	return table.map(row => row.map((cell, i) => `${cell}${repeatString(' ', maxLen[i] - cell.length + spacing)}`).join(''));
+}
+
+export function wordWrap(text: string, width: number = 80): string {
+	const [indent = ''] = text.match(/^\s+/) || [];
+	const maxWidth = width - indent.length;
+	return text
+		.replace(/^\s+/, '')
+		.split('')
+		.reduce(([out, buffer, pos], ch, i) => {
+			const nl = pos === maxWidth ? `\n${indent}` : '';
+			const newPos: number = nl ? 0 : +pos + 1;
+			return / |-|,|\./.test(ch) ?
+				[`${out}${buffer}${ch}${nl}`, '', newPos] : [`${out}${nl}`, buffer+ch, newPos];
+		}, [indent, '', 0])
+		.slice(0, 2)
+		.join('');
+};
+
+export function indentRow(row: string) { return `  ${row}`; };


### PR DESCRIPTION
This pr. contains the initial proposal for a “show” extension metadata command

Usage:
```bash
$ vsce show <extensionId>

# or as json

$ vsce show <extensionId> --json
```
![image](https://user-images.githubusercontent.com/1136718/32920689-90738af6-cb2a-11e7-9365-1538ccdb193f.png)
![image](https://user-images.githubusercontent.com/1136718/32920200-b4484ba8-cb28-11e7-9933-6cade13acb78.png)