### PR TITLE
fix show: add icon fallback on win32

### DIFF
--- a/src/show.ts
+++ b/src/show.ts
@@ -1,6 +1,6 @@
 import { getPublicGalleryAPI } from './util';
 import { ExtensionQueryFlags, PublishedExtension } from 'vso-node-api/interfaces/GalleryInterfaces';
-import { ViewTable, formatDate, formatDateTime, ratingStars, tableView, indentRow, wordWrap } from './viewutils';
+import { ViewTable, formatDate, formatDateTime, ratingStars, tableView, indentRow, wordWrap, icons } from './viewutils';
 
 const limitVersions = 6;
 
@@ -69,7 +69,7 @@ function showOverview({
 	// Render
 	console.log([
 		`${displayName}`,
-		`${publisherDisplayName} | ${'\u2913'}` +
+		`${publisherDisplayName} | ${icons.download} ` +
 		`${Number(installs).toLocaleString()} installs |` +
 		` ${ratingStars(averagerating)} (${ratingcount})`,
 		'',

--- a/src/viewutils.ts
+++ b/src/viewutils.ts
@@ -1,3 +1,5 @@
+const os = require('os');
+
 export type ViewTableRow = string[];
 export type ViewTable = ViewTableRow[];
 
@@ -8,6 +10,21 @@ const format = {
 };
 
 const columns = process.stdout.columns ? process.stdout.columns : 80;
+
+// xxx: Windows cmd + powershell standard fonts currently don't support the full
+// unicode charset. For now we use fallback icons when on windows.
+const useFallbackIcons = os.platform() === 'win32';
+
+export const icons = useFallbackIcons?
+{
+	download: '\u{2193}',
+	star: '\u{2665}',
+	emptyStar: '\u{2022}',
+} : {
+	download: '\u{2913}',
+	star: '\u{2605}',
+	emptyStar: '\u{2606}',
+};
 
 export function formatDate(date) { return date.toLocaleString(fixedLocale, format.date); }
 export function formatTime(date) { return date.toLocaleString(fixedLocale, format.time); }
@@ -23,7 +40,7 @@ export function repeatString(text: string, count: number): string {
 
 export function ratingStars(rating: number, total = 5): string {
 	const c = Math.min(Math.round(rating), total);
-	return `${repeatString('\u{2605} ', c)}${repeatString('\u{2606} ', total - c)}`;
+	return `${repeatString(icons.star + ' ', c)}${repeatString(icons.emptyStar + ' ', total - c)}`;
 }
 
 export function tableView(table: ViewTable, spacing: number = 2): string[] {


### PR DESCRIPTION
Both cmd and powershell fails to render the super nice unicode stars. It breaks my hearts... to make windows users use a fallback.

The issue circles unicode glyphs not in raster etc. fonts and the use of charpages.

fixes #221