### PR TITLE
Add execute permission for files in vsix

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -692,8 +692,8 @@ function writeVsix(files: IFile[], packagePath: string): Promise<string> {
 			const zip = new yazl.ZipFile();
 			let options = {
 				mtime: new Date(),
-				mode: parseInt("0100777", 8), // -rwxrwxrwx
-			  };
+				mode: parseInt("0100764", 8), // -rwxrw-r--
+			};
 			files.forEach(f => f.contents ? zip.addBuffer(typeof f.contents === 'string' ? new Buffer(f.contents, 'utf8') : f.contents, f.path, options) : zip.addFile(f.localPath, f.path, options));
 			zip.end();
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -690,7 +690,11 @@ function writeVsix(files: IFile[], packagePath: string): Promise<string> {
 		.catch(err => err.code !== 'ENOENT' ? Promise.reject(err) : Promise.resolve(null))
 		.then(() => new Promise<string>((c, e) => {
 			const zip = new yazl.ZipFile();
-			files.forEach(f => f.contents ? zip.addBuffer(typeof f.contents === 'string' ? new Buffer(f.contents, 'utf8') : f.contents, f.path) : zip.addFile(f.localPath, f.path));
+			let options = {
+				mtime: new Date(),
+				mode: parseInt("0100777", 8), // -rwxrwxrwx
+			  };
+			files.forEach(f => f.contents ? zip.addBuffer(typeof f.contents === 'string' ? new Buffer(f.contents, 'utf8') : f.contents, f.path, options) : zip.addFile(f.localPath, f.path, options));
 			zip.end();
 
 			const zipStream = fs.createWriteStream(packagePath);

--- a/typings/yazl.d.ts
+++ b/typings/yazl.d.ts
@@ -3,8 +3,8 @@ declare module 'yazl' {
 	
 	class ZipFile {
 		outputStream: stream.Stream;
-		addBuffer(buffer: Buffer, path: string);
-		addFile(localPath: string, path: string);
+		addBuffer(buffer: Buffer, path: string, options: any);
+		addFile(localPath: string, path: string, options: any);
 		end();
 	}
 }


### PR DESCRIPTION
Mac binaries packaged to a vsix on Windows were not executable when installing vsix on Mac. (mode 664). This change makes all files executable by the owner as well (mode 764). This might be an issue in yazl, since [they say](https://github.com/thejoshwolfe/yazl#addfilerealpath-metadatapath-options) they respect the original `stats.mode` of a file. In practice, the mode is not respected when you compare before/after creating vsix modes. @srivatsn 