### PR TITLE
if package path is a directory, use default file name to write vsix

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -822,6 +822,17 @@ function defaultPackagePath(cwd: string, manifest: Manifest): string {
 	return path.join(cwd, `${manifest.name}-${manifest.version}.vsix`);
 }
 
+function getPackagePath(packagePath: string, cwd: string, manifest: Manifest): string {
+	if (packagePath) {
+		if (path.extname(packagePath) !== '') {
+			return packagePath;
+		} else {
+			cwd = packagePath;
+		}
+	}
+	return defaultPackagePath(cwd, manifest);
+}
+
 function prepublish(cwd: string, manifest: Manifest): Promise<Manifest> {
 	if (!manifest.scripts || !manifest.scripts['vscode:prepublish']) {
 		return Promise.resolve(manifest);
@@ -848,9 +859,10 @@ export async function pack(options: IPackageOptions = {}): Promise<IPackageResul
 	if (files.length > 100) {
 		console.log(`This extension consists of ${files.length} separate files. For performance reasons, you should bundle your extension: https://aka.ms/vscode-bundle-extension`);
 	}
-	const packagePath = await writeVsix(files, path.resolve(options.packagePath || defaultPackagePath(cwd, manifest)));
+	const packagePath = await writeVsix(files, path.resolve(getPackagePath(options.packagePath, cwd, manifest)));
 
 	return { manifest, packagePath, files };
+
 }
 
 export async function packageCommand(options: IPackageOptions = {}): Promise<any> {


### PR DESCRIPTION
I improved the package path option.

If the given package output path is just a directory, it will be concatenated with the default file name (`{manifest.name}-${manifest.version}.vsix`) to write the VSIX file.
If it's a concrete file path, that will be used.

Otherwise, the default behaviour will be used. (current working directory with package name and version)

Hope you like it. Thanks for merging! 😊


