### PR TITLE
Support Yarn use in package command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,8 @@ module.exports = function (argv: string[]): void {
 		.option('-o, --out [path]', 'Location of the package')
 		.option('--baseContentUrl [url]', 'Prepend all relative links in README.md with this url.')
 		.option('--baseImagesUrl [url]', 'Prepend all relative image links in README.md with this url.')
-		.action(({ out, baseContentUrl, baseImagesUrl }) => main(packageCommand({ packagePath: out, baseContentUrl, baseImagesUrl })));
+		.option('--yarn', 'Use yarn instead of npm')
+		.action(({ out, baseContentUrl, baseImagesUrl, yarn }) => main(packageCommand({ packagePath: out, baseContentUrl, baseImagesUrl, useYarn: yarn })));
 
 	program
 		.command('publish [<version>]')

--- a/src/package.ts
+++ b/src/package.ts
@@ -63,6 +63,7 @@ export interface IPackageOptions {
 	packagePath?: string;
 	baseContentUrl?: string;
 	baseImagesUrl?: string;
+	useYarn?: boolean;
 }
 
 export interface IProcessor {
@@ -705,9 +706,10 @@ export function createDefaultProcessors(manifest: Manifest, options: IPackageOpt
 
 export function collect(manifest: Manifest, options: IPackageOptions = {}): Promise<IFile[]> {
 	const cwd = options.cwd || process.cwd();
+	const useYarn = options.useYarn || false;
 	const processors = createDefaultProcessors(manifest, options);
 
-	return collectFiles(cwd).then(fileNames => {
+	return collectFiles(cwd, useYarn).then(fileNames => {
 		const files = fileNames.map(f => ({ path: `extension/${f}`, localPath: path.join(cwd, f) }));
 
 		return processFiles(processors, files, options);


### PR DESCRIPTION
This fixes an issue where `npm list` thinks dependencies are invalid,
but a project uses Yarn and this can correctly handle the dependencies.
This is blocking SQL Ops Studio extensions that rely on
https://github.com/anthonydresser/dataprotocol-client, as this is marked
as invalid and essentially requires use of Yarn.

Please let me know if there's anything I should be doing in terms of testing etc. to help validate this. The basic test of using `vsce package --yarn` worked as expected and no longer caused packaging to fail.