### PR TITLE
Pull minimum translations out to manifest

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -93,7 +93,7 @@ interface ITranslation {
 	path: string;
 }
 
-let localizations: ILocalization[];
+let localizations: ILocalization[] = [];
 
 function getUrl(url: string | { url?: string; }): string {
 	if (!url) {
@@ -225,33 +225,6 @@ class ManifestProcessor extends BaseProcessor {
 		if (isGitHub) {
 			this.vsix.links.github = repository;
 		}
-
-		if (this.manifest.contributes && this.manifest.contributes['localizations'] && Array.isArray(this.manifest.contributes['localizations'])) {
-			localizations = this.manifest.contributes['localizations'];
-			localizations = localizations.map(x => {
-				return { ...x, mainTranslationPath: x.translations.filter(y => y.id === 'vscode' && !! y.path).map(y => util.normalize(path.join('extension', y.path)))[0] };
-			});
-		}
-	}
-
-	async onFile(file: IFile): Promise<IFile> {
-		const currentLoc = (localizations || []).filter(x => !x.minimalTranslations && x.mainTranslationPath === util.normalize(file.path))[0];
-		if (currentLoc) {
-			const contents = await read(file);
-			const contentsJson = JSON.parse(contents);
-			const translations = contentsJson["contents"] ? contentsJson["contents"]["vs/platform/node/minimalTranslations"] : null;
-			if (translations) {
-				currentLoc.minimalTranslations = {
-					"searchMarketplace": translations["searchMarketplace"],
-					"showLanguagePackExtensions": translations["showLanguagePackExtensions"],
-					"installAndRestartMessage": translations["installAndRestartMessage"],
-					"installAndRestart": translations["installAndRestart"],
-					"install": translations["install"]
-				};
-			}
-		}
-	
-		return file;
 	}
 
 	onEnd(): Promise<void> {
@@ -572,6 +545,37 @@ class IconProcessor extends BaseProcessor {
 	}
 }
 
+class LocProcessor extends BaseProcessor {
+	constructor(manifest: Manifest) {
+		super(manifest);
+		if (this.manifest.contributes && this.manifest.contributes['localizations'] && Array.isArray(this.manifest.contributes['localizations'])) {
+			localizations = this.manifest.contributes['localizations'];
+			localizations = localizations.map(x => {
+				return { ...x, mainTranslationPath: (x.translations || []).filter(y => y.id === 'vscode' && !!y.path).map(y => util.normalize(path.join('extension', y.path)))[0] };
+			}).filter(x => x.mainTranslationPath);
+		}
+	}
+
+	async onFile(file: IFile): Promise<IFile> {
+		const currentLoc = localizations.filter(x => x.mainTranslationPath === util.normalize(file.path))[0];
+		if (currentLoc) {
+			const contents = await read(file);
+			const contentsJson = JSON.parse(contents);
+			currentLoc.minimalTranslations = contentsJson["contents"] ? contentsJson["contents"]["vs/platform/node/minimalTranslations"] : null;
+		}
+
+		return file;
+	}
+
+	onEnd(): Promise<void> {
+		if (localizations.some(x => !x.minimalTranslations)) {
+			return Promise.reject(new Error(`At the bare minimum, translations for the "vs/platform/node/minimalTranslations" should be present in the extension.`));
+		}
+
+		return Promise.resolve<void>();;
+	}
+}
+
 export function validateManifest(manifest: Manifest): Manifest {
 	validatePublisher(manifest.publisher);
 	validateExtensionName(manifest.name);
@@ -716,18 +720,18 @@ function collectFiles(cwd: string, useYarn = false): Promise<string[]> {
 }
 
 async function addMinimalTranslations(files: IFile[]): Promise<void> {
-	if (!localizations) {
+	if (!localizations || !localizations.length) {
 		return;
 	}
 	for (let i = 0; i < files.length; i++) {
 		if (util.normalize(files[i].path) === 'extension/package.json') {
 			const contents = await read(files[i]);
 			const contentsJson = JSON.parse(contents);
-			
+
 			(<ILocalization[]>contentsJson["contributes"]["localizations"]).forEach(x => {
 				x.minimalTranslations = localizations.filter(y => y.languageId === x.languageId)[0].minimalTranslations;
 			});
-			
+
 			files[i].contents = new Buffer(JSON.stringify(contentsJson));
 			break;
 		}
@@ -760,7 +764,8 @@ export function createDefaultProcessors(manifest: Manifest, options: IPackageOpt
 		new ReadmeProcessor(manifest, options),
 		new ChangelogProcessor(manifest, options),
 		new LicenseProcessor(manifest),
-		new IconProcessor(manifest)
+		new IconProcessor(manifest),
+		new LocProcessor(manifest)
 	];
 }
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -229,13 +229,13 @@ class ManifestProcessor extends BaseProcessor {
 		if (this.manifest.contributes && this.manifest.contributes['localizations'] && Array.isArray(this.manifest.contributes['localizations'])) {
 			localizations = this.manifest.contributes['localizations'];
 			localizations = localizations.map(x => {
-				return { ...x, mainTranslationPath: x.translations.filter(y => y.id === 'vscode').map(y => util.normalize(path.join('extension', y.path)))[0] };
+				return { ...x, mainTranslationPath: x.translations.filter(y => y.id === 'vscode' && !! y.path).map(y => util.normalize(path.join('extension', y.path)))[0] };
 			});
 		}
 	}
 
 	async onFile(file: IFile): Promise<IFile> {
-		const currentLoc = localizations.filter(x => !x.minimalTranslations && x.mainTranslationPath === util.normalize(file.path))[0];
+		const currentLoc = (localizations || []).filter(x => !x.minimalTranslations && x.mainTranslationPath === util.normalize(file.path))[0];
 		if (currentLoc) {
 			const contents = await read(file);
 			const contentsJson = JSON.parse(contents);

--- a/src/package.ts
+++ b/src/package.ts
@@ -239,7 +239,7 @@ class ManifestProcessor extends BaseProcessor {
 		if (currentLoc) {
 			const contents = await read(file);
 			const contentsJson = JSON.parse(contents);
-			const translations = contentsJson["contents"] ? contentsJson["contents"]["vs/workbench/parts/extensions/electron-browser/extensionTipsService"] : null;
+			const translations = contentsJson["contents"] ? contentsJson["contents"]["vs/platform/node/minimalTranslations"] : null;
 			if (translations) {
 				currentLoc.minimalTranslations = {
 					"searchMarketplace": translations["searchMarketplace"],


### PR DESCRIPTION
Pull the [translations](https://github.com/Microsoft/vscode/blob/57cca7d272de3cef41bf8239f1547a39f82934c9/src/vs/platform/node/minimalTranslations.ts) needed to prompt user to install language pack to package.json so that they can be used by vscode without downloading the whole extension

Related to Microsoft/vscode#45663

cc @sandy081 @dbaeumer 