### PR TITLE
Add ability to publish using  'npm version'

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -23,7 +23,6 @@ interface IReadFile {
 }
 
 const readFile = denodeify<string, string, string>(fs.readFile);
-const writeFile = denodeify<string, string, string, void>(fs.writeFile as any);
 const unlink = denodeify<string, void>(fs.unlink as any);
 const exec = denodeify<string, { cwd?: string; env?: any; }, { stdout: string; stderr: string; }>(cp.exec as any, (err, stdout, stderr) => [err, { stdout, stderr }]);
 const glob = denodeify<string, _glob.Options, string[]>(_glob);
@@ -646,11 +645,6 @@ export function readManifest(cwd = process.cwd(), nls = true): Promise<Manifest>
 		return patchNLS(manifest, translations);
 	});
 
-}
-
-export function writeManifest(cwd: string, manifest: Manifest): Promise<void> {
-	const manifestPath = path.join(cwd, 'package.json');
-	return writeFile(manifestPath, JSON.stringify(manifest, null, 4), 'utf8');
 }
 
 export function toVsixManifest(assets: IAsset[], vsix: any, options: IPackageOptions = {}): Promise<string> {


### PR DESCRIPTION
Resolves #206 
References #180 

As per popular request `vsce publish <version>` will now use `npm version <version>`, in order to bump the package version. In the process, `package-lock.json` will also be updated (when using `npm5+`) and tagged `git` commit will be done (supporting `gpg` signing when it's set in `git` config).

**Note:** As before only `major`, `minor` and `patch` are supported as a valid ` <version>`.

I refrained from implementing a rollback of the process, as if anything goes wrong after the version bump (i.e. network issues), the user can simply execute `vsce publish` (without ` <version>`) and complete the publishing.

This implementation also does not interfere with using plain `vsce publish` via a CI service. Tthe user, in that case, should perform `npm version <version>` locally. Then push the commit and the tag. The CI publishing stage should only call `vsce publish -p <token>`.