### PR TITLE
Add property for supported languages

### DIFF
--- a/resources/extension.vsixmanifest
+++ b/resources/extension.vsixmanifest
@@ -12,6 +12,7 @@
       <Property Id="Microsoft.VisualStudio.Code.Engine" Value="<%- engine %>" />
       <Property Id="Microsoft.VisualStudio.Code.ExtensionDependencies" Value="<%- extensionDependencies %>" />
       <Property Id="Microsoft.VisualStudio.Code.ExtensionPack" Value="<%- extensionPack %>" />
+      <Property Id="Microsoft.VisualStudio.Code.LocalizedLanguages" Value="<%- localizedLanguages %>" />
       <% if (links.repository) { %>
         <Property Id="Microsoft.VisualStudio.Services.Links.Source" Value="<%- links.repository %>" />
         <Property Id="Microsoft.VisualStudio.Services.Links.Getstarted" Value="<%- links.repository %>" />

--- a/src/package.ts
+++ b/src/package.ts
@@ -208,7 +208,9 @@ class ManifestProcessor extends BaseProcessor {
 			enableMarketplaceQnA,
 			customerQnALink,
 			extensionDependencies: _(manifest.extensionDependencies || []).uniq().join(','),
-			extensionPack: _(manifest.extensionPack || []).uniq().join(',')
+			extensionPack: _(manifest.extensionPack || []).uniq().join(','),
+			localizedLanguages: (manifest.contributes && manifest.contributes.localizations) ?
+				manifest.contributes.localizations.map(loc => loc.languageNameLocalized || loc.languageName || loc.languageId).join(',') : ''
 		};
 
 		if (isGitHub) {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -999,6 +999,7 @@ describe('toVsixManifest', () => {
 				localizations: [
 					{
 						languageId: 'de',
+						languageName: 'German',
 						translations: [
 							{ id: 'vscode', path: 'de.json' },
 							{ id: 'vscode.go', path: 'what.json' }
@@ -1006,6 +1007,8 @@ describe('toVsixManifest', () => {
 					},
 					{
 						languageId: 'pt',
+						languageName: 'Portuguese',
+						languageNameLocalized: 'Português',
 						translations: [
 							{ id: 'vscode', path: './translations/pt.json' }
 						]
@@ -1025,6 +1028,15 @@ describe('toVsixManifest', () => {
 				const assets = result.PackageManifest.Assets[0].Asset;
 				assert(assets.some(asset => asset.$.Type === 'Microsoft.VisualStudio.Code.Translation.DE' && asset.$.Path === 'extension/de.json'));
 				assert(assets.some(asset => asset.$.Type === 'Microsoft.VisualStudio.Code.Translation.PT' && asset.$.Path === 'extension/translations/pt.json'));
+
+				const properties = result.PackageManifest.Metadata[0].Properties[0].Property;
+				const localizedLangProp = properties.filter(p => p.$.Id === 'Microsoft.VisualStudio.Code.LocalizedLanguages');
+				assert.equal(localizedLangProp.length, 1);
+
+				const localizedLangs = localizedLangProp[0].$.Value.split(',');
+				assert.equal(localizedLangs.length, 2);
+				assert.equal(localizedLangs[0], 'German');
+				assert.equal(localizedLangs[1], 'Português');
 			});
 	});
 


### PR DESCRIPTION
Related to https://github.com/Microsoft/vscode/pull/58563

This PR adds a new property to the vsixmanifest that contains the localized names of the languages supported by the extension.

