### PR TITLE
Respect Yarn choice when publishing

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -793,14 +793,16 @@ function defaultPackagePath(cwd: string, manifest: Manifest): string {
 	return path.join(cwd, `${manifest.name}-${manifest.version}.vsix`);
 }
 
-function prepublish(cwd: string, manifest: Manifest): Promise<Manifest> {
+function prepublish(cwd: string, manifest: Manifest, useYarn = false): Promise<Manifest> {
 	if (!manifest.scripts || !manifest.scripts['vscode:prepublish']) {
 		return Promise.resolve(manifest);
-	}
+  }
+  
+  const npmOrYarn = useYarn ? 'yarn' : 'npm';
 
-	console.warn(`Executing prepublish script 'npm run vscode:prepublish'...`);
+	console.warn(`Executing prepublish script '${npmOrYarn} run vscode:prepublish'...`);
 
-	return exec('npm run vscode:prepublish', { cwd })
+	return exec(`${npmOrYarn} run vscode:prepublish`, { cwd })
 		.then(({ stdout, stderr }) => {
 			process.stdout.write(stdout);
 			process.stderr.write(stderr);
@@ -813,7 +815,7 @@ export async function pack(options: IPackageOptions = {}): Promise<IPackageResul
 	const cwd = options.cwd || process.cwd();
 
 	let manifest = await readManifest(cwd);
-	manifest = await prepublish(cwd, manifest);
+	manifest = await prepublish(cwd, manifest, options.useYarn);
 
 	const files = await collect(manifest, options);
 	const packagePath = await writeVsix(files, path.resolve(options.packagePath || defaultPackagePath(cwd, manifest)));
@@ -852,7 +854,7 @@ export function listFiles(cwd = process.cwd(), useYarn = false, packagedDependen
  */
 export function ls(cwd = process.cwd(), useYarn = false, packagedDependencies?: string[]): Promise<void> {
 	return readManifest(cwd)
-		.then(manifest => prepublish(cwd, manifest))
+		.then(manifest => prepublish(cwd, manifest, useYarn))
 		.then(manifest => collectFiles(cwd, useYarn, packagedDependencies))
 		.then(files => files.forEach(f => console.log(`${f}`)));
 }


### PR DESCRIPTION
When the `--yarn` option is specified for publishing, respect its usage over npm.