### PR TITLE
img html tags in readme

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*		text=auto
+*.gif	binary
+*.jpg	binary
+*.png	binary

--- a/src/test/fixtures/readme/readme.expected.md
+++ b/src/test/fixtures/readme/readme.expected.md
@@ -26,6 +26,8 @@ The `spellMD.json` config file is watched so you can add more ignores or change 
 
 ![Add to dictionary](https://github.com/username/repository/raw/master/images/SpellMDDemo3.gif)
 
+<img src="https://github.com/username/repository/raw/master/images/SpellMDDemo4.gif" width="400px" />
+
 ![issue](https://github.com/username/repository/raw/master/issue)
 
 [mono](https://github.com/username/repository/blob/master/monkey)

--- a/src/test/fixtures/readme/readme.images.expected.md
+++ b/src/test/fixtures/readme/readme.images.expected.md
@@ -26,6 +26,8 @@ The `spellMD.json` config file is watched so you can add more ignores or change 
 
 ![Add to dictionary](https://github.com/username/repository/path/to/images/SpellMDDemo3.gif)
 
+<img src="https://github.com/username/repository/path/to/images/SpellMDDemo4.gif" width="400px" />
+
 ![issue](https://github.com/username/repository/path/to/issue)
 
 [mono](https://github.com/username/repository/blob/master/monkey)

--- a/src/test/fixtures/readme/readme.md
+++ b/src/test/fixtures/readme/readme.md
@@ -26,6 +26,8 @@ The `spellMD.json` config file is watched so you can add more ignores or change 
 
 ![Add to dictionary](/images/SpellMDDemo3.gif)
 
+<img src="/images/SpellMDDemo4.gif" width="400px" />
+
 ![issue](issue)
 
 [mono](monkey)


### PR DESCRIPTION
This is a quick hack to address issue #192. It adds a regex to match and modify relative URLs in `<img>` tags, taking care to watch out for `src="data:image/..."`. Test cases have been added.