### PR TITLE
Suggest bundling when having many files

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -840,6 +840,9 @@ export async function pack(options: IPackageOptions = {}): Promise<IPackageResul
 	manifest = await prepublish(cwd, manifest);
 
 	const files = await collect(manifest, options);
+	if (files.length > 100) {
+		console.log(`This extension consists of ${files.length} separate files. For performance reasons, you should bundle your extension: https://aka.ms/vscode-bundle-extension`);
+	}
 	const packagePath = await writeVsix(files, path.resolve(options.packagePath || defaultPackagePath(cwd, manifest)));
 
 	return { manifest, packagePath, files };


### PR DESCRIPTION
This for https://github.com/Microsoft/vscode-vsce/issues/333 and suggests to bundle when having an extension with more than 100 files. The limit 100 is a bit arbitrary tbh, open for other suggestions. 50? 1000?