### PR TITLE
Add badge.buildkite.com to trusted SVG sources

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -135,6 +135,7 @@ const TrustedSVGSources = [
 	'api.travis-ci.com',
 	'api.travis-ci.org',
 	'app.fossa.io',
+	'badge.buildkite.com',
 	'badge.fury.io',
 	'badge.waffle.io',
 	'badgen.net',


### PR DESCRIPTION
I maintain the Visual Studio Code extension for Bazel, Google's open-source build system (https://github.com/bazelbuild/vscode-bazel). Our CI host is [buildkite.com](https://buildkite.com/) ([pipeline](https://buildkite.com/bazel/vscode-bazel-vs-bazel)) and I would like to add their badge host to the list of trusted SVG sources (see [README.md](https://raw.githubusercontent.com/bazelbuild/vscode-bazel/master/README.md) for example).