### PR TITLE
Show up usage information the right way

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,8 @@ function main(task: Promise<any>): void {
 
 module.exports = function (argv: string[]): void {
 	program
-		.version(pkg.version);
+		.version(pkg.version)
+		.usage('<command> [options]');
 
 	program
 		.command('ls')


### PR DESCRIPTION
Fixes #349 

Fixed the usage information that showed up with  `--help` which was misleading previously.

`vsce --help` shows:-

```md
Usage: vsce <command> [options]

Options:
  -V, --version                        output the version number
  -h, --help                           output usage information

Commands:
  ls [options]                         Lists all the files that will be published
  package [options]                    Packages an extension
  publish [options] [<version>]        Publishes an extension
  unpublish [options] [<extensionid>]  Unpublishes an extension. Example extension id: microsoft.csharp.
  ls-publishers                        List all known publishers
  create-publisher <publisher>         Creates a new publisher
  delete-publisher <publisher>         Deletes a publisher
  login <publisher>                    Add a publisher to the known publishers list
  logout <publisher>                   Remove a publisher from the known publishers list
  show [options] <extensionid>         Show extension metadata
  search [options] <text>              search extension gallery

