### PR TITLE
Remove stub type definition for commander

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "devDependencies": {
     "@types/cheerio": "^0.22.1",
-    "@types/commander": "^2.12.2",
     "@types/denodeify": "^1.2.31",
     "@types/glob": "^7.1.1",
     "@types/lodash": "^4.14.123",
@@ -69,8 +68,8 @@
     "@types/semver": "^6.0.0",
     "@types/tmp": "^0.1.0",
     "@types/xml2js": "^0.4.4",
-    "cpx": "^1.5.0",
     "concurrently": "^4.1.0",
+    "cpx": "^1.5.0",
     "mocha": "^5.2.0",
     "source-map-support": "^0.4.2",
     "typescript": "^3.4.3",


### PR DESCRIPTION
`@types/commander` package is deprecated.

commander provides its own type definitions and it is not required to install `@types/commander` as from the official [npm package repository](https://www.npmjs.com/package/@types/commander) page.