### PR TITLE
Changed log level to info.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ function main(task: Promise<any>): void {
 		.catch(fatal)
 		.then(() => {
 			if (latestVersion && semver.gt(latestVersion, pkg.version)) {
-				log.warn(`\nThe latest version of ${pkg.name} is ${latestVersion} and you have ${pkg.version}.\nUpdate it now: npm install -g ${pkg.name}`);
+				log.info(`\nThe latest version of ${pkg.name} is ${latestVersion} and you have ${pkg.version}.\nUpdate it now: npm install -g ${pkg.name}`);
 			} else {
 				token.cancel();
 			}


### PR DESCRIPTION
Log level for outdated version notice is changed from "WARNING" to "INFO". See screenshot. 

This addresses issue #367 

![vsce-package-screenshot](https://user-images.githubusercontent.com/39960033/60206535-c3ede000-9821-11e9-8b8b-8e370a438a70.jpg)
