### PR TITLE
feat: proper yarn workspace support

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -837,7 +837,14 @@ export function collect(manifest: Manifest, options: IPackageOptions = {}): Prom
 	const processors = createDefaultProcessors(manifest, options);
 
 	return collectFiles(cwd, useYarn, packagedDependencies).then(fileNames => {
-		const files = fileNames.map(f => ({ path: `extension/${f}`, localPath: path.join(cwd, f) }));
+		const files = fileNames.map(f => {
+			// In case of a yarn workspace the filepath can point to node_modules at a higher level, we can just strip that within the extension
+			let basePathF = f;
+			while(basePathF.indexOf('../') === 0) {
+				basePathF = basePathF.substr(3);
+			}
+			return ({ path: `extension/${basePathF}`, localPath: path.join(cwd, f) });
+		});
 
 		return processFiles(processors, files, options);
 	});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-vsce/issues/300

This PR changes the way yarn bundling is being done. 
The main thing to consider is that `yarn list` is nowhere close to what `npm ls` does so you cannot really rely on that for bundling, especially in a workspace context.

Instead the code goes through the dependency based on the node resolution algorithm https://nodejs.org/api/modules.html#modules_all_together

At package time this means we might end up with path like "../../../node_modules" which obviously do not make sense in a packaged environment, so those path are stripped to just be node_modules ...
