### PR TITLE
Improve error message when packaging an extension with an unchanged README.md

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -328,7 +328,7 @@ export class MarkdownProcessor extends BaseProcessor {
 		let contents = await read(file);
 
 		if (/This is the README for your extension /.test(contents)) {
-			throw new Error(`Make sure to edit the README.md file before you publish your extension.`);
+			throw new Error(`Make sure to edit the README.md file before you package or publish your extension.`);
 		}
 
 		const markdownPathRegex = /(!?)\[([^\]\[]*|!\[[^\]\[]*]\([^\)]+\))\]\(([^\)]+)\)/g;

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1594,4 +1594,13 @@ describe('MarkdownProcessor', () => {
 
 		await throws(() => processor.onFile(readme));
 	});
+
+	it('should catch an unchanged README.md', async () => {
+		const manifest = { name: 'test', publisher: 'mocha', version: '0.0.1', engines: Object.create(null), repository: 'https://github.com/username/repository' };
+		const contents = `This is the README for your extension `;
+		const processor = new ReadmeProcessor(manifest, {});
+		const readme = { path: 'extension/readme.md', contents };
+
+		await throws(() => processor.onFile(readme));
+	})
 });


### PR DESCRIPTION
"Resolves" #391

I put "Resolves" into quotes since it's not really a bug, I just think this improves the experience. The case that a readme is unchanged was also never tested, so I added a test as well. 

@joaomoreno maybe you want to have a look at this and add your 2 cents? :) thank you.