### PR TITLE
Warns the extension authors of `extensionKind` type change

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -42,6 +42,7 @@ export interface Manifest {
 	_testing?: string;
 	enableProposedApi?: boolean;
 	qna?: 'marketplace' | string | false;
+	extensionKind?: string[];
 
 	// optional (npm)
 	author?: string | Person;

--- a/src/package.ts
+++ b/src/package.ts
@@ -236,6 +236,10 @@ class ManifestProcessor extends BaseProcessor {
 	}
 
 	async onEnd(): Promise<void> {
+		if (typeof this.manifest.extensionKind === 'string') {
+			util.log.warn(`The 'extensionKind' property should be of type 'string[]'. Learn more at: https://github.com/microsoft/vscode/issues/85819`);
+		}
+
 		if (this.manifest.publisher === 'vscode-samples') {
 			throw new Error('It\'s not allowed to use the \'vscode-samples\' publisher. Learn more at: https://code.visualstudio.com/api/working-with-extensions/publishing-extension.');
 		}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-vsce/issues/403

@sandy081:

- This currently only emits a warning, doesn't prevent publishing... should it?
- I believe we need a better user facing message, maybe with a better link describing the adoption and the purpose of that property.