### PR TITLE
Log level for npm list command changed to error to increase compatibility

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -54,8 +54,8 @@ function checkNPM(cancellationToken?: CancellationToken): Promise<void> {
 
 function getNpmDependencies(cwd: string): Promise<string[]> {
 	return checkNPM()
-		.then(() => exec('npm list --production --parseable --depth=99999', { cwd, maxBuffer: 5000 * 1024 }))
 		.then(({ stdout }) => stdout
+		.then(() => exec('npm list --production --parseable --depth=99999 --loglevel=error', { cwd, maxBuffer: 5000 * 1024 }))
 			.split(/[\r\n]/)
 			.filter(dir => path.isAbsolute(dir)));
 }

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -54,8 +54,8 @@ function checkNPM(cancellationToken?: CancellationToken): Promise<void> {
 
 function getNpmDependencies(cwd: string): Promise<string[]> {
 	return checkNPM()
-		.then(({ stdout }) => stdout
 		.then(() => exec('npm list --production --parseable --depth=99999 --loglevel=error', { cwd, maxBuffer: 5000 * 1024 }))
+		.then(({ stdout }) => stdout
 			.split(/[\r\n]/)
 			.filter(dir => path.isAbsolute(dir)));
 }


### PR DESCRIPTION
* Changed log level to error instead of warning for `npm list` command