### PR TITLE
revert e4a8df59

### DIFF
--- a/src/test/validation.test.ts
+++ b/src/test/validation.test.ts
@@ -57,6 +57,8 @@ describe('validateVersion', () => {
 	it('should validate', () => {
 		validateVersion('1.0.0');
 		validateVersion('0.1.1');
+		validateVersion('0.1.1-1');
+		validateVersion('0.1.1-pre');
 
 		assert.throws(() => validateVersion('.'));
 		assert.throws(() => validateVersion('..'));
@@ -65,7 +67,6 @@ describe('validateVersion', () => {
 		assert.throws(() => validateVersion('.0.1'));
 		assert.throws(() => validateVersion('0.1.'));
 		assert.throws(() => validateVersion('0.0.0.1'));
-		assert.throws(() => validateVersion('0.1.1-pre'));
 	});
 });
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -31,10 +31,6 @@ export function validateVersion(version: string): void {
 	if (!semver.valid(version)) {
 		throw new Error(`Invalid extension version '${version}'`);
 	}
-
-	if (semver.prerelease(version)) {
-		throw new Error(`Invalid extension version '${version}: semver prerelease field is not supported`);
-	}
 }
 
 export function validateEngineCompatibility(version: string): void {
@@ -48,7 +44,7 @@ export function validateEngineCompatibility(version: string): void {
 }
 
 /**
- * User shouldn't use a newer version of @types/vscode than the one specified in engines.vscode 
+ * User shouldn't use a newer version of @types/vscode than the one specified in engines.vscode
  */
 export function validateVSCodeTypesCompatibility(engineVersion: string, typeVersion: string): void {
 	if (engineVersion === '*') {


### PR DESCRIPTION
Ref #415

> Is it possible that the server supports pre-releases starting with non-digit characters only? Should that be the case, I would ask to revert [e4a8df5](https://github.com/microsoft/vscode-vsce/commit/e4a8df59d34e1f6a83776256067cf11bff943f1f) ASAP.

**EDIT**

Actually, according to the CI job, this seems to be fixed upstream.

