### PR TITLE
Add --noGitHubIssueLinking to stop issue link expansion in package step

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -74,7 +74,8 @@ module.exports = function (argv: string[]): void {
 		.option('--baseImagesUrl [url]', 'Prepend all relative image links in README.md with this url.')
 		.option('--yarn', 'Use yarn instead of npm')
 		.option('--ignoreFile [path]', 'Indicate alternative .vscodeignore')
-		.action(({ out, baseContentUrl, baseImagesUrl, yarn, ignoreFile }) => main(packageCommand({ packagePath: out, baseContentUrl, baseImagesUrl, useYarn: yarn, ignoreFile })));
+		.option('--noGitHubIssueLinking', 'Prevent automatic expansion of GitHub-style issue syntax into links')
+		.action(({ out, baseContentUrl, baseImagesUrl, yarn, ignoreFile, noGitHubIssueLinking }) => main(packageCommand({ packagePath: out, baseContentUrl, baseImagesUrl, useYarn: yarn, ignoreFile, expandGitHubIssueLinks: noGitHubIssueLinking })));
 
 	program
 		.command('publish [<version>]')

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1551,6 +1551,33 @@ describe('MarkdownProcessor', () => {
 			});
 	});
 
+	it('should not replace issue links with urls if its a github repo but issue link expansion is disabled.', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://github.com/username/repository.git'
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, { expandGitHubIssueLinks: false });
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.github.md')
+		};
+
+		return processor.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.github.md'), 'utf8')
+					.then(expected => {
+						assert.equal(actual, expected);
+					});
+			});
+	});
+
 	it('should not replace issue links with urls if its not a github repo.', () => {
 		const manifest = {
 			name: 'test',


### PR DESCRIPTION
Adds an option to `vsce package` to prevent any expansion of GitHub issue references.

**Note**: This is a workaround for https://github.com/microsoft/vscode-vsce/issues/398, but is not a fix for that issue.