### PR TITLE
Change a console.warn to console.log for an informational message

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -927,7 +927,7 @@ async function prepublish(cwd: string, manifest: Manifest, useYarn: boolean = fa
 		return;
 	}
 
-	console.warn(`Executing prepublish script '${useYarn ? 'yarn' : 'npm'} run vscode:prepublish'...`);
+	console.log(`Executing prepublish script '${useYarn ? 'yarn' : 'npm'} run vscode:prepublish'...`);
 
 	const { stdout, stderr } = await exec(`${useYarn ? 'yarn' : 'npm'} run vscode:prepublish`, { cwd, maxBuffer: 5000 * 1024 });
 	process.stdout.write(stdout);


### PR DESCRIPTION
Azure DevOps is reporting this warning as an error.  Since this message is not really a warning, just a notification of which package tool is being used, it can be changed to `console.log`