### PR TITLE
Fixes #427: Automatically replace gitlab image links in README

### DIFF
--- a/src/test/fixtures/readmeGitLab/readme.expected.md
+++ b/src/test/fixtures/readmeGitLab/readme.expected.md
@@ -1,0 +1,47 @@
+# README
+
+>**Important:** Once installed the checker will only update if you add the setting `"spellMD.enable": true` to your `.vscode\settings.json` file.
+
+This README covers off:
+* [Functionality](#functionality)
+* [Install](#install)
+* [Run and Configure](#run-and-configure)
+* [Known Issues/Bugs](#known-issuesbugs)
+* [Backlog](#backlog)
+* [How to Debug](#how-to-debug)
+
+# Functionality
+
+Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
+
+![Underscores and hovers](https://gitlab.com/username/repository/-/raw/master/images/SpellMDDemo1.gif)
+
+The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
+
+[![Jump to issues](https://gitlab.com/username/repository/-/raw/master/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](https://gitlab.com/username/repository/-/raw/master/images/SpellMDDemo2.gif)](https://gitlab.com/username/repository/-/blob/master/monkey)
+![](https://gitlab.com/username/repository/-/raw/master/images/SpellMDDemo2.gif)
+<img src="https://gitlab.com/username/repository/-/raw/master/images/myImage.gif">
+
+The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
+
+![Add to dictionary](https://gitlab.com/username/repository/-/raw/master/images/SpellMDDemo3.gif)
+
+![issue](https://gitlab.com/username/repository/-/raw/master/issue)
+
+[mono](https://gitlab.com/username/repository/-/blob/master/monkey)
+[not](http://shouldnottouchthis/)
+
+# Install
+This extension is published in the VS Code Gallery.  So simply hit 'F1' and type 'ext inst' from there select `SpellMD` and follow instructions.
+
+
+To clone the extension and load locally...
+
+```
+git clone https://github.com/Microsoft/vscode-SpellMD.git
+npm install
+tsc
+```
+
+>**Note:** TypeScript 1.6 or higher is required you can check with `tsc -v` and if you need to upgrade then run `npm install -g typescript`.

--- a/src/test/fixtures/readmeGitLab/readme.images.expected.md
+++ b/src/test/fixtures/readmeGitLab/readme.images.expected.md
@@ -1,0 +1,47 @@
+# README
+
+>**Important:** Once installed the checker will only update if you add the setting `"spellMD.enable": true` to your `.vscode\settings.json` file.
+
+This README covers off:
+* [Functionality](#functionality)
+* [Install](#install)
+* [Run and Configure](#run-and-configure)
+* [Known Issues/Bugs](#known-issuesbugs)
+* [Backlog](#backlog)
+* [How to Debug](#how-to-debug)
+
+# Functionality
+
+Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
+
+![Underscores and hovers](https://gitlab.com/username/repository/path/to/images/SpellMDDemo1.gif)
+
+The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
+
+[![Jump to issues](https://gitlab.com/username/repository/path/to/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](https://gitlab.com/username/repository/path/to/images/SpellMDDemo2.gif)](https://gitlab.com/username/repository/-/blob/master/monkey)
+![](https://gitlab.com/username/repository/path/to/images/SpellMDDemo2.gif)
+<img src="https://gitlab.com/username/repository/path/to/images/myImage.gif">
+
+The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
+
+![Add to dictionary](https://gitlab.com/username/repository/path/to/images/SpellMDDemo3.gif)
+
+![issue](https://gitlab.com/username/repository/path/to/issue)
+
+[mono](https://gitlab.com/username/repository/-/blob/master/monkey)
+[not](http://shouldnottouchthis/)
+
+# Install
+This extension is published in the VS Code Gallery.  So simply hit 'F1' and type 'ext inst' from there select `SpellMD` and follow instructions.
+
+
+To clone the extension and load locally...
+
+```
+git clone https://github.com/Microsoft/vscode-SpellMD.git
+npm install
+tsc
+```
+
+>**Note:** TypeScript 1.6 or higher is required you can check with `tsc -v` and if you need to upgrade then run `npm install -g typescript`.

--- a/src/test/fixtures/readmeGitLab/readme.md
+++ b/src/test/fixtures/readmeGitLab/readme.md
@@ -1,0 +1,47 @@
+# README
+
+>**Important:** Once installed the checker will only update if you add the setting `"spellMD.enable": true` to your `.vscode\settings.json` file.
+
+This README covers off:
+* [Functionality](#functionality)
+* [Install](#install)
+* [Run and Configure](#run-and-configure)
+* [Known Issues/Bugs](#known-issuesbugs)
+* [Backlog](#backlog)
+* [How to Debug](#how-to-debug)
+
+# Functionality
+
+Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
+
+![Underscores and hovers](/images/SpellMDDemo1.gif)
+
+The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
+
+[![Jump to issues](images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](images/SpellMDDemo2.gif)](monkey)
+![](images/SpellMDDemo2.gif)
+<img src="/images/myImage.gif">
+
+The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
+
+![Add to dictionary](/images/SpellMDDemo3.gif)
+
+![issue](issue)
+
+[mono](monkey)
+[not](http://shouldnottouchthis/)
+
+# Install
+This extension is published in the VS Code Gallery.  So simply hit 'F1' and type 'ext inst' from there select `SpellMD` and follow instructions.
+
+
+To clone the extension and load locally...
+
+```
+git clone https://github.com/Microsoft/vscode-SpellMD.git
+npm install
+tsc
+```
+
+>**Note:** TypeScript 1.6 or higher is required you can check with `tsc -v` and if you need to upgrade then run `npm install -g typescript`.

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1493,7 +1493,61 @@ describe('MarkdownProcessor', () => {
 			});
 	});
 
-	it('should replace img urls with baseImagesUrl', () => {
+	it('should infer baseContentUrl if its a gitlab repo', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://gitlab.com/username/repository'
+		};
+
+		const root = fixture('readmeGitlab');
+		const processor = new ReadmeProcessor(manifest, {});
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md')
+		};
+
+		return processor.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.expected.md'), 'utf8')
+					.then(expected => {
+						assert.equal(actual, expected);
+					});
+			});
+	});
+
+	it('should infer baseContentUrl if its a gitlab repo (.git)', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://gitlab.com/username/repository.git'
+		};
+
+		const root = fixture('readmeGitlab');
+		const processor = new ReadmeProcessor(manifest, {});
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md')
+		};
+
+		return processor.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.expected.md'), 'utf8')
+					.then(expected => {
+						assert.equal(actual, expected);
+					});
+			});
+	});
+
+	it('should replace img urls with baseImagesUrl on a github repository', () => {
 		const manifest = {
 			name: 'test',
 			publisher: 'mocha',
@@ -1508,6 +1562,37 @@ describe('MarkdownProcessor', () => {
 		};
 
 		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, options);
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md')
+		};
+
+		return processor.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.images.expected.md'), 'utf8')
+					.then(expected => {
+						assert.equal(actual, expected);
+					});
+			});
+	});
+
+	it('should replace img urls with baseImagesUrl on a gitlab repository', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://gitlab.com/username/repository.git'
+		};
+
+		const options = {
+			baseImagesUrl: 'https://gitlab.com/username/repository/path/to'
+		};
+
+		const root = fixture('readmeGitlab');
 		const processor = new ReadmeProcessor(manifest, options);
 		const readme = {
 			path: 'extension/readme.md',


### PR DESCRIPTION
This replaces image links in README files for gitlab repositories, similar to how github currently functions. The difference is this does not expand issue, pull request, or other links.