### PR TITLE
Support injecting PAT from an environmental variable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ module.exports = function (argv: string[]): void {
 	program
 		.command('publish [<version>]')
 		.description('Publishes an extension')
-		.option('-p, --pat <token>', 'Personal Access Token')
+		.option('-p, --pat <token>', 'Personal Access Token', process.env['VSCE_PAT'])
 		.option('-m, --message <commit message>', 'Commit message used when calling `npm version`.')
 		.option('--packagePath [path]', 'Publish the VSIX package located at the specified path.')
 		.option('--baseContentUrl [url]', 'Prepend all relative links in README.md with this url.')


### PR DESCRIPTION
This change adds a default value to the `-p` (`--pat`) option for the publish command based on an environmental variable.

Making this change creates an implicit default value for providing a personal access token, making it easier to trigger VSCE releases from CI platforms where global installation of modules is not possible (i.e. publish a VSCE extension via an `npm run...` command).