### PR TITLE
Update launch.json to be useful for extension debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,13 +8,14 @@
 			"type": "node",
 			"request": "launch",
 			"name": "Launch Program",
+			// "cwd": "<absolute path to your extension>",
 			"program": "${workspaceFolder}/out/vsce",
 			"args": [
 				"--version"
+				// "ls", "package", "publish"
 			],
 			"sourceMaps": true,
-			"outputCapture": "std",
-			"preLaunchTask": "compile"
+			"outputCapture": "std"
 		}
 	]
 }


### PR DESCRIPTION
When I worked on debugging https://github.com/microsoft/vscode-vsce/issues/432#issuecomment-650148223, I needed to make the extension work locally. This configuration change was very useful for running a local development version to package an extension. 