### PR TITLE
Fix issues with missing out directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "vsce": "out/vsce"
   },
   "scripts": {
-    "compile": "tsc && cp src/vsce out/vsce",
-    "watch": "cp src/vsce out/vsce && tsc --watch",
-    "watch-test": "cp src/vsce out/vsce && concurrently \"tsc --watch\" \"mocha --watch\"",
+    "copy-vsce": "mkdir -p out && cp src/vsce out/vsce",
+    "compile": "tsc && yarn copy-vsce",
+    "watch": "yarn copy-vsce && tsc --watch",
+    "watch-test": "yarn copy-vsce && concurrently \"tsc --watch\" \"mocha --watch\"",
     "test": "mocha",
-    "prepublishOnly": "tsc && cp src/vsce out/vsce && mocha",
+    "prepublishOnly": "tsc && yarn copy-vsce && mocha",
     "vsce": "out/vsce"
   },
   "engines": {


### PR DESCRIPTION
The `out` directory is not present directly after checkout and so running `yarn watch` fails.

```
~/w/c/vscode-vsce ❯❯❯ yarn watch                                                                                     ✘ 1
yarn run v1.15.2
$ cp src/vsce out/vsce && tsc --watch
cp: out/vsce: No such file or directory
error Command failed with exit code 1.
```

This fixes the issue by making sure the `out` directory exists