### PR TITLE
Add githubBranch flag to control the branch for GitHub relative links

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -70,12 +70,13 @@ module.exports = function (argv: string[]): void {
 		.command('package')
 		.description('Packages an extension')
 		.option('-o, --out [path]', 'Output .vsix extension file to [path] location')
+		.option('--githubBranch [branch]', 'The GitHub branch used to infer relative links in README.md. Can be overriden by --baseContentUrl and --baseImagesUrl.')
 		.option('--baseContentUrl [url]', 'Prepend all relative links in README.md with this url.')
 		.option('--baseImagesUrl [url]', 'Prepend all relative image links in README.md with this url.')
 		.option('--yarn', 'Use yarn instead of npm')
 		.option('--ignoreFile [path]', 'Indicate alternative .vscodeignore')
 		.option('--noGitHubIssueLinking', 'Prevent automatic expansion of GitHub-style issue syntax into links')
-		.action(({ out, baseContentUrl, baseImagesUrl, yarn, ignoreFile, noGitHubIssueLinking }) => main(packageCommand({ packagePath: out, baseContentUrl, baseImagesUrl, useYarn: yarn, ignoreFile, expandGitHubIssueLinks: noGitHubIssueLinking })));
+		.action(({ out, githubBranch, baseContentUrl, baseImagesUrl, yarn, ignoreFile, noGitHubIssueLinking }) => main(packageCommand({ packagePath: out, githubBranch, baseContentUrl, baseImagesUrl, useYarn: yarn, ignoreFile, expandGitHubIssueLinks: noGitHubIssueLinking })));
 
 	program
 		.command('publish [<version>]')
@@ -83,12 +84,13 @@ module.exports = function (argv: string[]): void {
 		.option('-p, --pat <token>', 'Personal Access Token', process.env['VSCE_PAT'])
 		.option('-m, --message <commit message>', 'Commit message used when calling `npm version`.')
 		.option('--packagePath [path]', 'Publish the VSIX package located at the specified path.')
+		.option('--githubBranch [branch]', 'The GitHub branch used to infer relative links in README.md. Can be overriden by --baseContentUrl and --baseImagesUrl.')
 		.option('--baseContentUrl [url]', 'Prepend all relative links in README.md with this url.')
 		.option('--baseImagesUrl [url]', 'Prepend all relative image links in README.md with this url.')
 		.option('--yarn', 'Use yarn instead of npm while packing extension files')
 		.option('--noVerify')
 		.option('--ignoreFile [path]', 'Indicate alternative .vscodeignore')
-		.action((version, { pat, message, packagePath, baseContentUrl, baseImagesUrl, yarn, noVerify, ignoreFile }) => main(publish({ pat, commitMessage: message, version, packagePath, baseContentUrl, baseImagesUrl, useYarn: yarn, noVerify, ignoreFile })));
+		.action((version, { pat, message, packagePath, githubBranch, baseContentUrl, baseImagesUrl, yarn, noVerify, ignoreFile }) => main(publish({ pat, commitMessage: message, version, packagePath, githubBranch, baseContentUrl, baseImagesUrl, useYarn: yarn, noVerify, ignoreFile })));
 
 	program
 		.command('unpublish [<extensionid>]')

--- a/src/package.ts
+++ b/src/package.ts
@@ -59,6 +59,7 @@ export interface IAsset {
 export interface IPackageOptions {
 	cwd?: string;
 	packagePath?: string;
+	githubBranch?: string;
 	baseContentUrl?: string;
 	baseImagesUrl?: string;
 	useYarn?: boolean;
@@ -365,7 +366,7 @@ export class MarkdownProcessor extends BaseProcessor {
 	constructor(manifest: Manifest, private name: string, private regexp: RegExp, private assetType: string, options: IPackageOptions = {}) {
 		super(manifest);
 
-		const guess = this.guessBaseUrls();
+		const guess = this.guessBaseUrls(options.githubBranch);
 
 		this.baseContentUrl = options.baseContentUrl || (guess && guess.content);
 		this.baseImagesUrl = options.baseImagesUrl || options.baseContentUrl || (guess && guess.images);
@@ -492,7 +493,7 @@ export class MarkdownProcessor extends BaseProcessor {
 	}
 
 	// GitHub heuristics
-	private guessBaseUrls(): { content: string; images: string; repository: string } {
+	private guessBaseUrls(githubBranch: string | undefined): { content: string; images: string; repository: string } {
 		let repository = null;
 
 		if (typeof this.manifest.repository === 'string') {
@@ -514,10 +515,11 @@ export class MarkdownProcessor extends BaseProcessor {
 
 		const account = match[1];
 		const repositoryName = match[2].replace(/\.git$/i, '');
+		const branchName = githubBranch ? githubBranch : 'master';
 
 		return {
-			content: `https://github.com/${account}/${repositoryName}/blob/master`,
-			images: `https://github.com/${account}/${repositoryName}/raw/master`,
+			content: `https://github.com/${account}/${repositoryName}/blob/${branchName}`,
+			images: `https://github.com/${account}/${repositoryName}/raw/${branchName}`,
 			repository: `https://github.com/${account}/${repositoryName}`
 		};
 	}

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -92,6 +92,7 @@ export interface IPublishOptions {
 	commitMessage?: string;
 	cwd?: string;
 	pat?: string;
+	githubBranch?: string;
 	baseContentUrl?: string;
 	baseImagesUrl?: string;
 	useYarn?: boolean;
@@ -156,6 +157,7 @@ export function publish(options: IPublishOptions = {}): Promise<any> {
 			.then(manifest => ({ manifest, packagePath: options.packagePath }));
 	} else {
 		const cwd = options.cwd;
+		const githubBranch = options.githubBranch;
 		const baseContentUrl = options.baseContentUrl;
 		const baseImagesUrl = options.baseImagesUrl;
 		const useYarn = options.useYarn;
@@ -163,7 +165,7 @@ export function publish(options: IPublishOptions = {}): Promise<any> {
 
 		promise = versionBump(options.cwd, options.version, options.commitMessage)
 			.then(() => tmpName())
-			.then(packagePath => pack({ packagePath, cwd, baseContentUrl, baseImagesUrl, useYarn, ignoreFile }));
+			.then(packagePath => pack({ packagePath, cwd, githubBranch, baseContentUrl, baseImagesUrl, useYarn, ignoreFile }));
 	}
 
 	return promise.then(({ manifest, packagePath }) => {

--- a/src/test/fixtures/readme/readme.branch.expected.md
+++ b/src/test/fixtures/readme/readme.branch.expected.md
@@ -1,0 +1,48 @@
+# README
+
+>**Important:** Once installed the checker will only update if you add the setting `"spellMD.enable": true` to your `.vscode\settings.json` file.
+
+This README covers off:
+* [Functionality](#functionality)
+* [Install](#install)
+* [Run and Configure](#run-and-configure)
+* [Known Issues/Bugs](#known-issuesbugs)
+* [Backlog](#backlog)
+* [How to Debug](#how-to-debug)
+
+# Functionality
+
+Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
+
+![Underscores and hovers](https://github.com/username/repository/raw/master/images/SpellMDDemo1.gif)
+
+The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
+
+[![Jump to issues](https://github.com/username/repository/raw/master/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](https://github.com/username/repository/raw/master/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/main/monkey)
+![](https://github.com/username/repository/raw/master/images/SpellMDDemo2.gif)
+<img src="https://github.com/username/repository/raw/master/images/myImage.gif">
+
+The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
+
+![Add to dictionary](https://github.com/username/repository/raw/master/images/SpellMDDemo3.gif)
+
+![issue](https://github.com/username/repository/raw/master/issue)
+
+[mono](https://github.com/username/repository/blob/main/monkey)
+[not](http://shouldnottouchthis/)
+[Email me](mailto:example@example.com)
+
+# Install
+This extension is published in the VS Code Gallery.  So simply hit 'F1' and type 'ext inst' from there select `SpellMD` and follow instructions.
+
+
+To clone the extension and load locally...
+
+```
+git clone https://github.com/Microsoft/vscode-SpellMD.git
+npm install
+tsc
+```
+
+>**Note:** TypeScript 1.6 or higher is required you can check with `tsc -v` and if you need to upgrade then run `npm install -g typescript`.

--- a/src/test/fixtures/readme/readme.branch.main.expected.md
+++ b/src/test/fixtures/readme/readme.branch.main.expected.md
@@ -1,0 +1,48 @@
+# README
+
+>**Important:** Once installed the checker will only update if you add the setting `"spellMD.enable": true` to your `.vscode\settings.json` file.
+
+This README covers off:
+* [Functionality](#functionality)
+* [Install](#install)
+* [Run and Configure](#run-and-configure)
+* [Known Issues/Bugs](#known-issuesbugs)
+* [Backlog](#backlog)
+* [How to Debug](#how-to-debug)
+
+# Functionality
+
+Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
+
+![Underscores and hovers](https://github.com/username/repository/raw/main/images/SpellMDDemo1.gif)
+
+The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
+
+[![Jump to issues](https://github.com/username/repository/raw/main/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](https://github.com/username/repository/raw/main/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/main/monkey)
+![](https://github.com/username/repository/raw/main/images/SpellMDDemo2.gif)
+<img src="https://github.com/username/repository/raw/main/images/myImage.gif">
+
+The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
+
+![Add to dictionary](https://github.com/username/repository/raw/main/images/SpellMDDemo3.gif)
+
+![issue](https://github.com/username/repository/raw/main/issue)
+
+[mono](https://github.com/username/repository/blob/main/monkey)
+[not](http://shouldnottouchthis/)
+[Email me](mailto:example@example.com)
+
+# Install
+This extension is published in the VS Code Gallery.  So simply hit 'F1' and type 'ext inst' from there select `SpellMD` and follow instructions.
+
+
+To clone the extension and load locally...
+
+```
+git clone https://github.com/Microsoft/vscode-SpellMD.git
+npm install
+tsc
+```
+
+>**Note:** TypeScript 1.6 or higher is required you can check with `tsc -v` and if you need to upgrade then run `npm install -g typescript`.

--- a/src/test/fixtures/readme/readme.branch.override.content.expected.md
+++ b/src/test/fixtures/readme/readme.branch.override.content.expected.md
@@ -14,22 +14,22 @@ This README covers off:
 
 Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
 
-![Underscores and hovers](https://github.com/username/repository/raw/master/images/SpellMDDemo1.gif)
+![Underscores and hovers](https://github.com/base/images/SpellMDDemo1.gif)
 
 The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
 
-[![Jump to issues](https://github.com/username/repository/raw/master/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
-[![Jump to issues](https://github.com/username/repository/raw/master/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/main/monkey)
-![](https://github.com/username/repository/raw/master/images/SpellMDDemo2.gif)
-<img src="https://github.com/username/repository/raw/master/images/myImage.gif">
+[![Jump to issues](https://github.com/base/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](https://github.com/base/images/SpellMDDemo2.gif)](https://github.com/base/monkey)
+![](https://github.com/base/images/SpellMDDemo2.gif)
+<img src="https://github.com/base/images/myImage.gif">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 
-![Add to dictionary](https://github.com/username/repository/raw/master/images/SpellMDDemo3.gif)
+![Add to dictionary](https://github.com/base/images/SpellMDDemo3.gif)
 
-![issue](https://github.com/username/repository/raw/master/issue)
+![issue](https://github.com/base/issue)
 
-[mono](https://github.com/username/repository/blob/main/monkey)
+[mono](https://github.com/base/monkey)
 [not](http://shouldnottouchthis/)
 [Email me](mailto:example@example.com)
 

--- a/src/test/fixtures/readme/readme.branch.override.images.expected.md
+++ b/src/test/fixtures/readme/readme.branch.override.images.expected.md
@@ -1,0 +1,48 @@
+# README
+
+>**Important:** Once installed the checker will only update if you add the setting `"spellMD.enable": true` to your `.vscode\settings.json` file.
+
+This README covers off:
+* [Functionality](#functionality)
+* [Install](#install)
+* [Run and Configure](#run-and-configure)
+* [Known Issues/Bugs](#known-issuesbugs)
+* [Backlog](#backlog)
+* [How to Debug](#how-to-debug)
+
+# Functionality
+
+Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
+
+![Underscores and hovers](https://github.com/base/images/SpellMDDemo1.gif)
+
+The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
+
+[![Jump to issues](https://github.com/base/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](https://github.com/base/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/main/monkey)
+![](https://github.com/base/images/SpellMDDemo2.gif)
+<img src="https://github.com/base/images/myImage.gif">
+
+The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
+
+![Add to dictionary](https://github.com/base/images/SpellMDDemo3.gif)
+
+![issue](https://github.com/base/issue)
+
+[mono](https://github.com/username/repository/blob/main/monkey)
+[not](http://shouldnottouchthis/)
+[Email me](mailto:example@example.com)
+
+# Install
+This extension is published in the VS Code Gallery.  So simply hit 'F1' and type 'ext inst' from there select `SpellMD` and follow instructions.
+
+
+To clone the extension and load locally...
+
+```
+git clone https://github.com/Microsoft/vscode-SpellMD.git
+npm install
+tsc
+```
+
+>**Note:** TypeScript 1.6 or higher is required you can check with `tsc -v` and if you need to upgrade then run `npm install -g typescript`.

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1466,6 +1466,37 @@ describe('MarkdownProcessor', () => {
 			});
 	});
 
+	it('should respect specified GitHub branch and can be overriden', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://github.com/username/repository'
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, {
+			githubBranch: 'main',
+			// Override image relative links to point to different base URL
+			baseImagesUrl: 'https://github.com/username/repository/raw/master'
+		});
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md')
+		};
+
+		return processor.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.branch.expected.md'), 'utf8')
+					.then(expected => {
+						assert.equal(actual, expected);
+					});
+			});
+	});
+
 	it('should infer baseContentUrl if its a github repo (.git)', () => {
 		const manifest = {
 			name: 'test',

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1466,7 +1466,7 @@ describe('MarkdownProcessor', () => {
 			});
 	});
 
-	it('should respect specified GitHub branch and can be overriden', () => {
+	it('should replace relative links with GitHub URLs while respecting githubBranch', () => {
 		const manifest = {
 			name: 'test',
 			publisher: 'mocha',
@@ -1478,9 +1478,7 @@ describe('MarkdownProcessor', () => {
 
 		const root = fixture('readme');
 		const processor = new ReadmeProcessor(manifest, {
-			githubBranch: 'main',
-			// Override image relative links to point to different base URL
-			baseImagesUrl: 'https://github.com/username/repository/raw/master'
+			githubBranch: 'main'
 		});
 		const readme = {
 			path: 'extension/readme.md',
@@ -1490,13 +1488,80 @@ describe('MarkdownProcessor', () => {
 		return processor.onFile(readme)
 			.then(file => read(file))
 			.then(actual => {
-				return readFile(path.join(root, 'readme.branch.expected.md'), 'utf8')
+				return readFile(path.join(root, 'readme.branch.main.expected.md'), 'utf8')
 					.then(expected => {
 						assert.equal(actual, expected);
 					});
 			});
 	});
 
+	it("should override image URLs with baseImagesUrl while also respecting githubBranch", () => {
+		const manifest = {
+			name: "test",
+			publisher: "mocha",
+			version: "0.0.1",
+			description: "test extension",
+			engines: Object.create(null),
+			repository: "https://github.com/username/repository",
+		};
+
+		const root = fixture("readme");
+		const processor = new ReadmeProcessor(manifest, {
+			githubBranch: "main",
+			// Override image relative links to point to different base URL
+			baseImagesUrl: "https://github.com/base",
+		});
+		const readme = {
+			path: "extension/readme.md",
+			localPath: path.join(root, "readme.md"),
+		};
+
+		return processor
+			.onFile(readme)
+			.then((file) => read(file))
+			.then((actual) => {
+				return readFile(
+				path.join(root, "readme.branch.override.images.expected.md"),
+				"utf8"
+				).then((expected) => {
+				assert.equal(actual, expected);
+				});
+			});
+	});
+
+	it("should override githubBranch setting with baseContentUrl", () => {
+		const manifest = {
+			name: "test",
+			publisher: "mocha",
+			version: "0.0.1",
+			description: "test extension",
+			engines: Object.create(null),
+			repository: "https://github.com/username/repository",
+		};
+
+		const root = fixture("readme");
+		const processor = new ReadmeProcessor(manifest, {
+			githubBranch: "main",
+			baseContentUrl: "https://github.com/base",
+		});
+		const readme = {
+			path: "extension/readme.md",
+			localPath: path.join(root, "readme.md"),
+		};
+
+		return processor
+			.onFile(readme)
+			.then((file) => read(file))
+			.then((actual) => {
+			return readFile(
+				path.join(root, "readme.branch.override.content.expected.md"),
+				"utf8"
+			).then((expected) => {
+				assert.equal(actual, expected);
+			});
+		});
+	});
+  
 	it('should infer baseContentUrl if its a github repo (.git)', () => {
 		const manifest = {
 			name: 'test',
@@ -1520,8 +1585,8 @@ describe('MarkdownProcessor', () => {
 				return readFile(path.join(root, 'readme.expected.md'), 'utf8')
 					.then(expected => {
 						assert.equal(actual, expected);
-					});
-			});
+				});
+		});
 	});
 
 	it('should replace img urls with baseImagesUrl', () => {


### PR DESCRIPTION
Fixes #468 

Currently if `repository` in `package.json` is set to a GitHub URL, all the relative links in `README.md` get converted to absolute links but they always refer to the `master` branch. This change adds a flag `githubBranch` which allows the user to override this assumption without having to use to override `baseImagesUrl` and `baseContentUrl`.

The `baseImageUrl` and `baseContentUrl` options take precedence over `githubBranch`, so doing something like: `vsce --githubBranch main --baseImagesUrl http://blah` will only change non-image relative links to stem from the `main`.
