### PR TITLE
support --web in vsce package

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -86,7 +86,11 @@ module.exports = function (argv: string[]): void {
 		.option('--yarn', 'Use yarn instead of npm')
 		.option('--ignoreFile [path]', 'Indicate alternative .vscodeignore')
 		.option('--noGitHubIssueLinking', 'Prevent automatic expansion of GitHub-style issue syntax into links')
-		.action(({ out, githubBranch, baseContentUrl, baseImagesUrl, yarn, ignoreFile, noGitHubIssueLinking }) =>
+		.option(
+			'--web',
+			'Experimental flag to enable publishing web extensions. Note: This is supported only for selected extensions.'
+		)
+		.action(({ out, githubBranch, baseContentUrl, baseImagesUrl, yarn, ignoreFile, noGitHubIssueLinking, web }) =>
 			main(
 				packageCommand({
 					packagePath: out,
@@ -96,6 +100,7 @@ module.exports = function (argv: string[]): void {
 					useYarn: yarn,
 					ignoreFile,
 					expandGitHubIssueLinks: noGitHubIssueLinking,
+					web
 				})
 			)
 		);


### PR DESCRIPTION
While troubleshooting why we can't publish Vim to the marketplace, we found we have to bundle it ourselves and then upload through the marketplace portal. It would be great if the options of `publish` and `package` align.