### PR TITLE
Adds detection for yarn, and '--no-yarn' to suppress detection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '8.x'
+      versionSpec: '10.x'
 
   - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
     inputs:

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,8 @@ module.exports = function (argv: string[]): void {
 	program
 		.command('ls')
 		.description('Lists all the files that will be published')
-		.option('--yarn', 'Use yarn instead of npm')
+		.option('--yarn', 'Use yarn instead of npm (default inferred from presense of yarn.lock or .yarnrc)')
+		.option('--no-yarn', 'Use npm instead of yarn (default inferred from lack of yarn.lock or .yarnrc)')
 		.option(
 			'--packagedDependencies <path>',
 			'Select packages that should be published only (includes dependencies)',
@@ -83,7 +84,8 @@ module.exports = function (argv: string[]): void {
 		)
 		.option('--baseContentUrl [url]', 'Prepend all relative links in README.md with this url.')
 		.option('--baseImagesUrl [url]', 'Prepend all relative image links in README.md with this url.')
-		.option('--yarn', 'Use yarn instead of npm')
+		.option('--yarn', 'Use yarn instead of npm (default inferred from presense of yarn.lock or .yarnrc)')
+		.option('--no-yarn', 'Use npm instead of yarn (default inferred from lack of yarn.lock or .yarnrc)')
 		.option('--ignoreFile [path]', 'Indicate alternative .vscodeignore')
 		.option('--noGitHubIssueLinking', 'Prevent automatic expansion of GitHub-style issue syntax into links')
 		.option(
@@ -117,7 +119,8 @@ module.exports = function (argv: string[]): void {
 		)
 		.option('--baseContentUrl [url]', 'Prepend all relative links in README.md with this url.')
 		.option('--baseImagesUrl [url]', 'Prepend all relative image links in README.md with this url.')
-		.option('--yarn', 'Use yarn instead of npm while packing extension files')
+		.option('--yarn', 'Use yarn instead of npm (default inferred from presense of yarn.lock or .yarnrc)')
+		.option('--no-yarn', 'Use npm instead of yarn (default inferred from lack of yarn.lock or .yarnrc)')
 		.option('--noVerify')
 		.option('--ignoreFile [path]', 'Indicate alternative .vscodeignore')
 		.option(

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -181,7 +181,10 @@ async function getYarnProductionDependencies(cwd: string, packagedDependencies?:
 async function getYarnDependencies(cwd: string, packagedDependencies?: string[]): Promise<string[]> {
 	const result: string[] = [cwd];
 
-	if (await new Promise(c => fs.exists(path.join(cwd, 'yarn.lock'), c))) {
+	// Using 'existsSync' instead of 'exists' since 'exists' is deprecated. While 'fs.existsSync'
+	// is a blocking IO operation, this won't affect the CLI as every code path that calls
+	// 'getYarnDependencies' essentially blocks the CLI anyways while waiting for `exists` to complete.
+	if (fs.existsSync(path.join(cwd, 'yarn.lock'))) {
 		const deps = await getYarnProductionDependencies(cwd, packagedDependencies);
 		const flatten = (dep: YarnDependency) => {
 			result.push(dep.path);

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,9 +1,17 @@
 import * as path from 'path';
 import * as fs from 'fs';
+import * as denodeify from 'denodeify';
 import * as cp from 'child_process';
 import * as parseSemver from 'parse-semver';
 import * as _ from 'lodash';
-import { CancellationToken } from './util';
+import { CancellationToken, log } from './util';
+
+const stat = denodeify(fs.stat);
+const exists = (file: string) =>
+	stat(file).then(
+		_ => true,
+		_ => false
+	);
 
 interface IOptions {
 	cwd?: string;
@@ -181,10 +189,7 @@ async function getYarnProductionDependencies(cwd: string, packagedDependencies?:
 async function getYarnDependencies(cwd: string, packagedDependencies?: string[]): Promise<string[]> {
 	const result: string[] = [cwd];
 
-	// Using 'existsSync' instead of 'exists' since 'exists' is deprecated. While 'fs.existsSync'
-	// is a blocking IO operation, this won't affect the CLI as every code path that calls
-	// 'getYarnDependencies' essentially blocks the CLI anyways while waiting for `exists` to complete.
-	if (fs.existsSync(path.join(cwd, 'yarn.lock'))) {
+	if (await exists(path.join(cwd, 'yarn.lock'))) {
 		const deps = await getYarnProductionDependencies(cwd, packagedDependencies);
 		const flatten = (dep: YarnDependency) => {
 			result.push(dep.path);
@@ -196,8 +201,26 @@ async function getYarnDependencies(cwd: string, packagedDependencies?: string[])
 	return _.uniq(result);
 }
 
-export function getDependencies(cwd: string, useYarn = false, packagedDependencies?: string[]): Promise<string[]> {
-	return useYarn ? getYarnDependencies(cwd, packagedDependencies) : getNpmDependencies(cwd);
+export async function detectYarn(cwd: string) {
+	for (const file of ['yarn.lock', '.yarnrc']) {
+		if (await exists(path.join(cwd, file))) {
+			log.info(
+				`Detected presense of ${file}. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).`
+			);
+			return true;
+		}
+	}
+	return false;
+}
+
+export async function getDependencies(
+	cwd: string,
+	useYarn?: boolean,
+	packagedDependencies?: string[]
+): Promise<string[]> {
+	return (useYarn !== undefined ? useYarn : await detectYarn(cwd))
+		? await getYarnDependencies(cwd, packagedDependencies)
+		: await getNpmDependencies(cwd);
 }
 
 export function getLatestVersion(name: string, cancellationToken?: CancellationToken): Promise<string> {

--- a/src/package.ts
+++ b/src/package.ts
@@ -1128,7 +1128,9 @@ async function prepublish(cwd: string, manifest: Manifest, useYarn?: boolean): P
 		return;
 	}
 
-	if (useYarn === undefined) useYarn = await detectYarn(cwd);
+	if (useYarn === undefined) {
+		useYarn = await detectYarn(cwd);
+	}
 
 	console.log(`Executing prepublish script '${useYarn ? 'yarn' : 'npm'} run vscode:prepublish'...`);
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -21,7 +21,7 @@ import {
 	validateEngineCompatibility,
 	validateVSCodeTypesCompatibility,
 } from './validation';
-import { getDependencies } from './npm';
+import { detectYarn, getDependencies } from './npm';
 import { IExtensionsReport } from './publicgalleryapi';
 
 const readFile = denodeify<string, string, string>(fs.readFile);
@@ -984,7 +984,7 @@ const defaultIgnore = [
 	'**/.vscode-test/**',
 ];
 
-function collectAllFiles(cwd: string, useYarn = detectYarn(cwd), dependencyEntryPoints?: string[]): Promise<string[]> {
+function collectAllFiles(cwd: string, useYarn?: boolean, dependencyEntryPoints?: string[]): Promise<string[]> {
 	return getDependencies(cwd, useYarn, dependencyEntryPoints).then(deps => {
 		const promises: Promise<string[]>[] = deps.map(dep => {
 			return glob('**', { cwd: dep, nodir: true, dot: true, ignore: 'node_modules/**' }).then(files =>
@@ -998,7 +998,7 @@ function collectAllFiles(cwd: string, useYarn = detectYarn(cwd), dependencyEntry
 
 function collectFiles(
 	cwd: string,
-	useYarn = detectYarn(cwd),
+	useYarn?: boolean,
 	dependencyEntryPoints?: string[],
 	ignoreFile?: string
 ): Promise<string[]> {
@@ -1084,12 +1084,11 @@ export function createDefaultProcessors(manifest: Manifest, options: IPackageOpt
 
 export function collect(manifest: Manifest, options: IPackageOptions = {}): Promise<IFile[]> {
 	const cwd = options.cwd || process.cwd();
-	const useYarn = options.useYarn === undefined ? detectYarn(cwd) : options.useYarn;
 	const packagedDependencies = options.dependencyEntryPoints || undefined;
 	const ignoreFile = options.ignoreFile || undefined;
 	const processors = createDefaultProcessors(manifest, options);
 
-	return collectFiles(cwd, useYarn, packagedDependencies, ignoreFile).then(fileNames => {
+	return collectFiles(cwd, options.useYarn, packagedDependencies, ignoreFile).then(fileNames => {
 		const files = fileNames.map(f => ({ path: `extension/${f}`, localPath: path.join(cwd, f) }));
 
 		return processFiles(processors, files);
@@ -1124,10 +1123,12 @@ function getDefaultPackageName(manifest: Manifest): string {
 	return `${manifest.name}-${manifest.version}.vsix`;
 }
 
-async function prepublish(cwd: string, manifest: Manifest, useYarn: boolean = detectYarn(cwd)): Promise<void> {
+async function prepublish(cwd: string, manifest: Manifest, useYarn?: boolean): Promise<void> {
 	if (!manifest.scripts || !manifest.scripts['vscode:prepublish']) {
 		return;
 	}
+
+	if (useYarn === undefined) useYarn = await detectYarn(cwd);
 
 	console.log(`Executing prepublish script '${useYarn ? 'yarn' : 'npm'} run vscode:prepublish'...`);
 
@@ -1155,16 +1156,6 @@ async function getPackagePath(cwd: string, manifest: Manifest, options: IPackage
 	} catch {
 		return options.packagePath;
 	}
-}
-
-function detectYarn(cwd: string) {
-	for (const file of ["yarn.lock", ".yarnrc"]) {
-		if (fs.existsSync(path.join(cwd, file))) {
-			console.log(`Detected presense of ${file}. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).`);
-			return true;
-		}
-	}
-	return false;
 }
 
 export async function pack(options: IPackageOptions = {}): Promise<IPackageResult> {
@@ -1210,13 +1201,14 @@ export async function packageCommand(options: IPackageOptions = {}): Promise<any
 /**
  * Lists the files included in the extension's package. Does not run prepublish.
  */
-export function listFiles(
+export async function listFiles(
 	cwd = process.cwd(),
-	useYarn = detectYarn(cwd),
+	useYarn?: boolean,
 	packagedDependencies?: string[],
 	ignoreFile?: string
 ): Promise<string[]> {
-	return readManifest(cwd).then(() => collectFiles(cwd, useYarn, packagedDependencies, ignoreFile));
+	await readManifest(cwd);
+	return await collectFiles(cwd, useYarn, packagedDependencies, ignoreFile);
 }
 
 /**
@@ -1224,7 +1216,7 @@ export function listFiles(
  */
 export function ls(
 	cwd = process.cwd(),
-	useYarn = detectYarn(cwd),
+	useYarn?: boolean,
 	packagedDependencies?: string[],
 	ignoreFile?: string
 ): Promise<void> {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -209,6 +209,23 @@ describe('collect', function () {
 			});
 	});
 
+	it('should detect yarn', () => {
+		const cwd = fixture('packagedDependencies');
+
+		return readManifest(cwd)
+			.then(manifest => collect(manifest, { cwd, dependencyEntryPoints: ['isexe'] }))
+			.then(files => {
+				let seenWhich: boolean;
+				let seenIsexe: boolean;
+				files.forEach(file => {
+					seenWhich = file.path.indexOf('/node_modules/which/') >= 0;
+					seenIsexe = file.path.indexOf('/node_modules/isexe/') >= 0;
+				});
+				assert.equal(seenWhich, false);
+				assert.equal(seenIsexe, true);
+			});
+	});
+
 	it('should include all node_modules when dependencyEntryPoints is not defined', () => {
 		const cwd = fixture('packagedDependencies');
 


### PR DESCRIPTION
This adds automatic detection of `yarn` based on the presence of either a `yarn.lock` or `.yarnrc` file in the current directory. Passing `--yarn` or `--no-yarn` disables automatic detection.

Fixes #480