### PR TITLE
Ensure package.json is writable in *.vsix

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -210,7 +210,7 @@ function isHostTrusted(url: url.UrlWithStringQuery): boolean {
 	return TrustedSVGSources.indexOf(url.host.toLowerCase()) > -1 || isGitHubBadge(url.href);
 }
 
-class ManifestProcessor extends BaseProcessor {
+export class ManifestProcessor extends BaseProcessor {
 	constructor(manifest: Manifest) {
 		super(manifest);
 

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -13,6 +13,7 @@ import {
 	WebExtensionProcessor,
 	IAsset,
 	IPackageOptions,
+	ManifestProcessor,
 } from '../package';
 import { Manifest } from '../manifest';
 import * as path from 'path';
@@ -1681,6 +1682,21 @@ describe('toContentTypes', () => {
 				);
 				assert.ok(!result.Types.Default.some(d => d.$.Extension === ''));
 			});
+	});
+});
+
+describe('ManifestProcessor', () => {
+	it('should ensure that package.json is writable', async () => {
+		const root = fixture('uuid');
+		const manifest = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+		const processor = new ManifestProcessor(manifest);
+		const packageJson = {
+			path: 'extension/package.json',
+			localPath: path.join(root, 'package.json'),
+		};
+
+		const outPackageJson = await processor.onFile(packageJson);
+		assert.ok(outPackageJson.mode & 0o200);
 	});
 });
 


### PR DESCRIPTION
VSC requires the manifest file unpacked from the .vsix archive to be
marked as writable (see [1]). Since generating writable artifacts is
difficult in some build systems (such as Bazel), it would be helpful if
vsce itself could ensure that the file mode of the manifest is correct.

With this commit, the correct file mode on `package.json` is set
automatically by the packaging process via a new `Processor` and yazl's
`mode` argument.

[1]: https://github.com/microsoft/vscode/blob/88144f6d31718288c7a2c6fb741e0646d40804cf/src/vs/platform/extensionManagement/node/extensionsScanner.ts#L144