### PR TITLE
set `expandGitHubIssueLinks` to inverse of `noGitHubIssueLinking`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,7 @@ module.exports = function (argv: string[]): void {
 					baseImagesUrl,
 					useYarn: yarn,
 					ignoreFile,
-					expandGitHubIssueLinks: noGitHubIssueLinking,
+					expandGitHubIssueLinks: !noGitHubIssueLinking,
 					web,
 				})
 			)


### PR DESCRIPTION
This PR contains handling `noGitHubIssueLinking` option and variable `expandGitHubIssueLinks` properly.

According to `commandar`, `noGitHubIssueLinking` can be `true` or `undefined`, cannot be `false` because the option name doesn't start with `--no-`.
So `expandGitHubIssueLinks` is same.
https://github.com/tj/commander.js#other-option-types-negatable-boolean-and-booleanvalue

On current implementation, the `expandGitHubIssueLinks` is always `true` after this conditional operator if `expandGitHubIssueLinks` cannot be `false`, as reported in #542 
https://github.com/microsoft/vscode-vsce/blob/f186af2ab56ff78725bf9285c09b52f64e0988f7/src/package.ts#L441-L442
