### PR TITLE
Allow version bump in package command

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
 	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 	// List of extensions which should be recommended for users of this workspace.
-	"recommendations": ["hbenl.vscode-mocha-test-adapter"],
+	"recommendations": ["hbenl.vscode-mocha-test-adapter", "esbenp.prettier-vscode"],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,6 @@
 		"out": true
 	},
 	"typescript.tsdk": "./node_modules/typescript/lib",
-	"mochaExplorer.files": "out/**/test/*.test.js",
 	"[json]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,14 @@
 		"out": true
 	},
 	"typescript.tsdk": "./node_modules/typescript/lib",
-	"mochaExplorer.files": "out/**/test/*.test.js"
+	"mochaExplorer.files": "out/**/test/*.test.js",
+	"[json]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	}
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,11 +16,11 @@ steps:
   - script: yarn
     displayName: Install Dependencies
 
-  - script: yarn compile
-    displayName: Compile
-
   - script: yarn test
     displayName: Run Tests
+
+  - script: yarn build
+    displayName: Build
 
   - task: Npm@1
     displayName: 'Publish to NPM'

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"prettier": "2.1.2",
 		"pretty-quick": "^3.0.2",
 		"source-map-support": "^0.4.2",
-		"ts-node": "^10.0.0",
+		"ts-node": "9",
 		"typescript": "^4.3.2",
 		"xml2js": "^0.4.12"
 	},

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
 		"vsce": "out/vsce"
 	},
 	"scripts": {
-		"copy-vsce": "mkdir -p out && cp src/vsce out/vsce",
-		"compile": "tsc && yarn copy-vsce",
-		"watch": "yarn copy-vsce && tsc --watch",
-		"watch-test": "yarn copy-vsce && concurrently \"tsc --watch\" \"mocha --watch\"",
+		"copy-vsce": "mkdir -p out && cp -f src/vsce out/vsce",
+		"build": "yarn copy-vsce && tsc",
+		"build:watch": "yarn compile -- --watch",
 		"test": "mocha",
-		"prepublishOnly": "tsc && yarn copy-vsce && mocha",
+		"test:watch": "yarn copy-vsce && yarn test -- --watch",
+		"prepublishOnly": "yarn compile && yarn test",
 		"vsce": "out/vsce"
 	},
 	"engines": {
@@ -51,7 +51,7 @@
 		"parse-semver": "^1.1.1",
 		"read": "^1.0.7",
 		"semver": "^5.1.0",
-		"tmp": "0.0.29",
+		"tmp": "^0.2.1",
 		"typed-rest-client": "^1.8.4",
 		"url-join": "^1.1.0",
 		"yauzl": "^2.3.1",
@@ -77,14 +77,15 @@
 		"prettier": "2.1.2",
 		"pretty-quick": "^3.0.2",
 		"source-map-support": "^0.4.2",
+		"ts-node": "^10.0.0",
 		"typescript": "^4.3.2",
 		"xml2js": "^0.4.12"
 	},
 	"mocha": {
 		"require": [
-			"source-map-support/register"
+			"ts-node/register"
 		],
-		"spec": "out/test"
+		"spec": "src/test/**/*.ts"
 	},
 	"husky": {
 		"hooks": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,9 +75,11 @@ module.exports = function (argv: string[]): void {
 		);
 
 	program
-		.command('package')
+		.command('package [<version>]')
 		.description('Packages an extension')
-		.option('-o, --out [path]', 'Output .vsix extension file to [path] location')
+		.option('-o, --out [path]', 'Output .vsix extension file to [path] location (defaults to <name>-<version>.vsix)')
+		.option('-m, --message <commit message>', 'Commit message used when calling `npm version`.')
+		.option('--no-git-tag-version', 'Do not create a version commit and tag when calling `npm version`.')
 		.option(
 			'--githubBranch [branch]',
 			'The GitHub branch used to infer relative links in README.md. Can be overriden by --baseContentUrl and --baseImagesUrl.'
@@ -98,21 +100,29 @@ module.exports = function (argv: string[]): void {
 			'Experimental flag to enable publishing web extensions. Note: This is supported only for selected extensions.'
 		)
 		.action(
-			({
-				out,
-				githubBranch,
-				gitlabBranch,
-				baseContentUrl,
-				baseImagesUrl,
-				yarn,
-				ignoreFile,
-				gitHubIssueLinking,
-				gitLabIssueLinking,
-				web,
-			}) =>
+			(
+				version,
+				{
+					out,
+					message,
+					gitTagVersion,
+					githubBranch,
+					gitlabBranch,
+					baseContentUrl,
+					baseImagesUrl,
+					yarn,
+					ignoreFile,
+					gitHubIssueLinking,
+					gitLabIssueLinking,
+					web,
+				}
+			) =>
 				main(
 					packageCommand({
 						packagePath: out,
+						version,
+						commitMessage: message,
+						gitTagVersion,
 						githubBranch,
 						gitlabBranch,
 						baseContentUrl,
@@ -135,6 +145,7 @@ module.exports = function (argv: string[]): void {
 			process.env['VSCE_PAT']
 		)
 		.option('-m, --message <commit message>', 'Commit message used when calling `npm version`.')
+		.option('--no-git-tag-version', 'Do not create a version commit and tag when calling `npm version`.')
 		.option('--packagePath [path]', 'Publish the VSIX package located at the specified path.')
 		.option(
 			'--githubBranch [branch]',
@@ -160,6 +171,7 @@ module.exports = function (argv: string[]): void {
 				{
 					pat,
 					message,
+					gitTagVersion,
 					packagePath,
 					githubBranch,
 					gitlabBranch,
@@ -174,8 +186,9 @@ module.exports = function (argv: string[]): void {
 				main(
 					publish({
 						pat,
-						commitMessage: message,
 						version,
+						commitMessage: message,
+						gitTagVersion,
 						packagePath,
 						githubBranch,
 						gitlabBranch,

--- a/src/package.ts
+++ b/src/package.ts
@@ -228,7 +228,7 @@ export async function versionBump(
 	cwd: string = process.cwd(),
 	version?: string,
 	commitMessage?: string,
-	gitTagVersion?: boolean
+	gitTagVersion: boolean = true
 ): Promise<void> {
 	if (!version) {
 		return Promise.resolve(null);

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -123,51 +123,6 @@ export interface IPublishOptions {
 	readonly web?: boolean;
 }
 
-async function versionBump(cwd: string = process.cwd(), version?: string, commitMessage?: string): Promise<void> {
-	if (!version) {
-		return Promise.resolve(null);
-	}
-
-	const manifest = await readManifest(cwd);
-
-	if (manifest.version === version) {
-		return null;
-	}
-
-	switch (version) {
-		case 'major':
-		case 'minor':
-		case 'patch':
-			break;
-		case 'premajor':
-		case 'preminor':
-		case 'prepatch':
-		case 'prerelease':
-		case 'from-git':
-			return Promise.reject(`Not supported: ${version}`);
-		default:
-			if (!semver.valid(version)) {
-				return Promise.reject(`Invalid version ${version}`);
-			}
-	}
-
-	let command = `npm version ${version}`;
-
-	if (commitMessage) {
-		command = `${command} -m "${commitMessage}"`;
-	}
-
-	try {
-		// call `npm version` to do our dirty work
-		const { stdout, stderr } = await exec(command, { cwd });
-		process.stdout.write(stdout);
-		process.stderr.write(stderr);
-		return null;
-	} catch (err) {
-		throw err.message;
-	}
-}
-
 export function publish(options: IPublishOptions = {}): Promise<any> {
 	let promise: Promise<IPackage>;
 

--- a/src/test/fixtures/version/package.json
+++ b/src/test/fixtures/version/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "version",
+	"publisher": "felipecrs",
+	"version": "1.0.0",
+	"engines": {
+		"vscode": "*"
+	}
+}

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -2687,6 +2687,8 @@ describe('version', () => {
 		cwd = dir.name;
 		fs.copyFileSync(path.join(fixtureFolder, 'package.json'), path.join(cwd, 'package.json'));
 		git(['init']);
+		git(['config', '--local', 'user.name', 'Sample Name']);
+		git(['config', '--local', 'user.email', 'sample@email.com']);
 	});
 
 	afterEach(() => {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -2717,20 +2717,24 @@ describe('version', () => {
 		assert.strictEqual(newManifest.version, '2.0.0');
 	});
 
-	it('should not fail with same version', async () => {
-		await versionBump(cwd, '1.0.0');
-
-		const newManifest = await readManifest(cwd);
-
-		assert.strictEqual(newManifest.version, '1.0.0');
-	});
-
 	it('should set custom version', async () => {
 		await versionBump(cwd, '1.1.1');
 
 		const newManifest = await readManifest(cwd);
 
 		assert.strictEqual(newManifest.version, '1.1.1');
+	});
+
+	it('should fail with not allowed version bump', () => {
+		assert.rejects(versionBump(cwd, 'prepatch'));
+		assert.rejects(versionBump(cwd, 'preminor'));
+		assert.rejects(versionBump(cwd, 'premajor'));
+		assert.rejects(versionBump(cwd, 'prerelease'));
+		assert.rejects(versionBump(cwd, 'from-git'));
+	});
+
+	it('should fail with invalid version', () => {
+		assert.rejects(versionBump(cwd, 'a1.a.2'));
 	});
 
 	it('should create git tag and commit', async () => {
@@ -2740,17 +2744,17 @@ describe('version', () => {
 		assert.strictEqual(git(['rev-parse', 'HEAD']).status, 0);
 	});
 
-	it('should not create git tag and commit', async () => {
-		await versionBump(cwd, '1.1.1', undefined, false);
-
-		assert.notDeepStrictEqual(git(['rev-parse', 'v1.1.1']).status, 0);
-		assert.notDeepStrictEqual(git(['rev-parse', 'HEAD']).status, 0);
-	});
-
 	it('should use custom commit message', async () => {
 		const commitMessage = 'test commit message';
 		await versionBump(cwd, '1.1.1', commitMessage);
 
 		assert.deepStrictEqual(git(['show', '-s', '--format=%B', 'HEAD']).stdout, `${commitMessage}\n\n`);
+	});
+
+	it('should not create git tag and commit', async () => {
+		await versionBump(cwd, '1.1.1', undefined, false);
+
+		assert.notDeepStrictEqual(git(['rev-parse', 'v1.1.1']).status, 0);
+		assert.notDeepStrictEqual(git(['rev-parse', 'HEAD']).status, 0);
 	});
 });


### PR DESCRIPTION
And add the `--no-git-tag-version` option to disable the creation of version commit and tag when calling `npm version`.

## Plus

- Set prettier as the default formatter for JSON and Typescript files in VS Code and add it to the list of recommended extensions
- Improve `package --out` help message
- Format `main.ts` with Prettier
- Move `versionBump` from `publish.ts` to `package.ts` as it is where it is used first now
- Use `ts-node` with `mocha`
- Upgrade `tmp`
- Revamp the `package.json` scripts by simplifying and renaming some
