### PR TITLE
Add support for GitLab.com

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -82,29 +82,48 @@ module.exports = function (argv: string[]): void {
 			'--githubBranch [branch]',
 			'The GitHub branch used to infer relative links in README.md. Can be overriden by --baseContentUrl and --baseImagesUrl.'
 		)
+		.option(
+			'--gitlabBranch [branch]',
+			'The GitLab branch used to infer relative links in README.md. Can be overriden by --baseContentUrl and --baseImagesUrl.'
+		)
 		.option('--baseContentUrl [url]', 'Prepend all relative links in README.md with this url.')
 		.option('--baseImagesUrl [url]', 'Prepend all relative image links in README.md with this url.')
 		.option('--yarn', 'Use yarn instead of npm (default inferred from presence of yarn.lock or .yarnrc)')
 		.option('--no-yarn', 'Use npm instead of yarn (default inferred from lack of yarn.lock or .yarnrc)')
 		.option('--ignoreFile [path]', 'Indicate alternative .vscodeignore')
 		.option('--no-gitHubIssueLinking', 'Disable automatic expansion of GitHub-style issue syntax into links')
+		.option('--no-gitLabIssueLinking', 'Disable automatic expansion of GitLab-style issue syntax into links')
 		.option(
 			'--web',
 			'Experimental flag to enable publishing web extensions. Note: This is supported only for selected extensions.'
 		)
-		.action(({ out, githubBranch, baseContentUrl, baseImagesUrl, yarn, ignoreFile, gitHubIssueLinking, web }) =>
-			main(
-				packageCommand({
-					packagePath: out,
-					githubBranch,
-					baseContentUrl,
-					baseImagesUrl,
-					useYarn: yarn,
-					ignoreFile,
-					gitHubIssueLinking,
-					web,
-				})
-			)
+		.action(
+			({
+				out,
+				githubBranch,
+				gitlabBranch,
+				baseContentUrl,
+				baseImagesUrl,
+				yarn,
+				ignoreFile,
+				gitHubIssueLinking,
+				gitLabIssueLinking,
+				web,
+			}) =>
+				main(
+					packageCommand({
+						packagePath: out,
+						githubBranch,
+						gitlabBranch,
+						baseContentUrl,
+						baseImagesUrl,
+						useYarn: yarn,
+						ignoreFile,
+						gitHubIssueLinking,
+						gitLabIssueLinking,
+						web,
+					})
+				)
 		);
 
 	program
@@ -121,6 +140,10 @@ module.exports = function (argv: string[]): void {
 			'--githubBranch [branch]',
 			'The GitHub branch used to infer relative links in README.md. Can be overriden by --baseContentUrl and --baseImagesUrl.'
 		)
+		.option(
+			'--gitlabBranch [branch]',
+			'The GitLab branch used to infer relative links in README.md. Can be overriden by --baseContentUrl and --baseImagesUrl.'
+		)
 		.option('--baseContentUrl [url]', 'Prepend all relative links in README.md with this url.')
 		.option('--baseImagesUrl [url]', 'Prepend all relative image links in README.md with this url.')
 		.option('--yarn', 'Use yarn instead of npm (default inferred from presence of yarn.lock or .yarnrc)')
@@ -134,7 +157,19 @@ module.exports = function (argv: string[]): void {
 		.action(
 			(
 				version,
-				{ pat, message, packagePath, githubBranch, baseContentUrl, baseImagesUrl, yarn, noVerify, ignoreFile, web }
+				{
+					pat,
+					message,
+					packagePath,
+					githubBranch,
+					gitlabBranch,
+					baseContentUrl,
+					baseImagesUrl,
+					yarn,
+					noVerify,
+					ignoreFile,
+					web,
+				}
 			) =>
 				main(
 					publish({
@@ -143,6 +178,7 @@ module.exports = function (argv: string[]): void {
 						version,
 						packagePath,
 						githubBranch,
+						gitlabBranch,
 						baseContentUrl,
 						baseImagesUrl,
 						useYarn: yarn,

--- a/src/package.ts
+++ b/src/package.ts
@@ -79,12 +79,14 @@ export interface IPackageOptions {
 	readonly cwd?: string;
 	readonly packagePath?: string;
 	readonly githubBranch?: string;
+	readonly gitlabBranch?: string;
 	readonly baseContentUrl?: string;
 	readonly baseImagesUrl?: string;
 	readonly useYarn?: boolean;
 	readonly dependencyEntryPoints?: string[];
 	readonly ignoreFile?: string;
 	readonly gitHubIssueLinking?: boolean;
+	readonly gitLabIssueLinking?: boolean;
 	readonly web?: boolean;
 }
 
@@ -200,6 +202,10 @@ const TrustedSVGSources = [
 
 function isGitHubRepository(repository: string): boolean {
 	return /^https:\/\/github\.com\/|^git@github\.com:/.test(repository || '');
+}
+
+function isGitLabRepository(repository: string): boolean {
+	return /^https:\/\/gitlab\.com\/|^git@gitlab\.com:/.test(repository || '');
 }
 
 function isGitHubBadge(href: string): boolean {
@@ -420,8 +426,10 @@ export class MarkdownProcessor extends BaseProcessor {
 	private baseContentUrl: string;
 	private baseImagesUrl: string;
 	private isGitHub: boolean;
+	private isGitLab: boolean;
 	private repositoryUrl: string;
 	private gitHubIssueLinking: boolean;
+	private gitLabIssueLinking: boolean;
 
 	constructor(
 		manifest: Manifest,
@@ -432,13 +440,15 @@ export class MarkdownProcessor extends BaseProcessor {
 	) {
 		super(manifest);
 
-		const guess = this.guessBaseUrls(options.githubBranch);
+		const guess = this.guessBaseUrls(options.githubBranch || options.gitlabBranch);
 
 		this.baseContentUrl = options.baseContentUrl || (guess && guess.content);
 		this.baseImagesUrl = options.baseImagesUrl || options.baseContentUrl || (guess && guess.images);
 		this.repositoryUrl = guess && guess.repository;
 		this.isGitHub = isGitHubRepository(this.repositoryUrl);
+		this.isGitLab = isGitLabRepository(this.repositoryUrl);
 		this.gitHubIssueLinking = typeof options.gitHubIssueLinking === 'boolean' ? options.gitHubIssueLinking : true;
+		this.gitLabIssueLinking = typeof options.gitLabIssueLinking === 'boolean' ? options.gitLabIssueLinking : true;
 	}
 
 	async onFile(file: IFile): Promise<IFile> {
@@ -505,7 +515,7 @@ export class MarkdownProcessor extends BaseProcessor {
 			return all.replace(link, urljoin(prefix, link));
 		});
 
-		if (this.gitHubIssueLinking && this.isGitHub) {
+		if ((this.gitHubIssueLinking && this.isGitHub) || (this.gitLabIssueLinking && this.isGitLab)) {
 			const markdownIssueRegex = /(\s|\n)([\w\d_-]+\/[\w\d_-]+)?#(\d+)\b/g;
 			const issueReplace = (
 				all: string,
@@ -523,11 +533,19 @@ export class MarkdownProcessor extends BaseProcessor {
 
 				if (owner && repositoryName && issueNumber) {
 					// Issue in external repository
-					const issueUrl = urljoin('https://github.com', owner, repositoryName, 'issues', issueNumber);
+					const issueUrl = this.isGitHub
+						? urljoin('https://github.com', owner, repositoryName, 'issues', issueNumber)
+						: urljoin('https://gitlab.com', owner, repositoryName, '-', 'issues', issueNumber);
 					result = prefix + `[${owner}/${repositoryName}#${issueNumber}](${issueUrl})`;
 				} else if (!owner && !repositoryName && issueNumber) {
 					// Issue in own repository
-					result = prefix + `[#${issueNumber}](${urljoin(this.repositoryUrl, 'issues', issueNumber)})`;
+					result =
+						prefix +
+						`[#${issueNumber}](${
+							this.isGitHub
+								? urljoin(this.repositoryUrl, 'issues', issueNumber)
+								: urljoin(this.repositoryUrl, '-', 'issues', issueNumber)
+						})`;
 				}
 
 				return result;
@@ -569,7 +587,7 @@ export class MarkdownProcessor extends BaseProcessor {
 	}
 
 	// GitHub heuristics
-	private guessBaseUrls(githubBranch: string | undefined): { content: string; images: string; repository: string } {
+	private guessBaseUrls(githostBranch: string | undefined): { content: string; images: string; repository: string } {
 		let repository = null;
 
 		if (typeof this.manifest.repository === 'string') {
@@ -582,22 +600,36 @@ export class MarkdownProcessor extends BaseProcessor {
 			return null;
 		}
 
-		const regex = /github\.com\/([^/]+)\/([^/]+)(\/|$)/;
-		const match = regex.exec(repository);
+		const gitHubRegex = /(?<domain>github\.com)(?<project>\/(?:[^/]+)\/(?:[^/]+))(\/|$)/;
+		const gitLabRegex = /(?<domain>gitlab\.com)(?<project>(?:\/([^/]+)){2,})$/;
+		const match = ((gitHubRegex.exec(repository) || gitLabRegex.exec(repository)) as unknown) as {
+			groups: Record<string, string>;
+		};
 
 		if (!match) {
 			return null;
 		}
 
-		const account = match[1];
-		const repositoryName = match[2].replace(/\.git$/i, '');
-		const branchName = githubBranch ? githubBranch : 'HEAD';
+		const project = match.groups.project.substring(1).replace(/\.git$/i, '');
+		const branchName = githostBranch ? githostBranch : 'HEAD';
+		switch (match.groups.domain) {
+			case 'github.com':
+				return {
+					content: `https://github.com/${project}/blob/${branchName}`,
+					images: `https://github.com/${project}/raw/${branchName}`,
+					repository: `https://github.com/${project}`,
+				};
 
-		return {
-			content: `https://github.com/${account}/${repositoryName}/blob/${branchName}`,
-			images: `https://github.com/${account}/${repositoryName}/raw/${branchName}`,
-			repository: `https://github.com/${account}/${repositoryName}`,
-		};
+			case 'gitlab.com':
+				return {
+					content: `https://gitlab.com/${project}/-/blob/${branchName}`,
+					images: `https://gitlab.com/${project}/-/raw/${branchName}`,
+					repository: `https://gitlab.com/${project}`,
+				};
+
+			default:
+				return null;
+		}
 	}
 }
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -119,6 +119,7 @@ export interface IPublishOptions {
 	cwd?: string;
 	pat?: string;
 	githubBranch?: string;
+	gitlabBranch?: string;
 	baseContentUrl?: string;
 	baseImagesUrl?: string;
 	useYarn?: boolean;
@@ -190,6 +191,7 @@ export function publish(options: IPublishOptions = {}): Promise<any> {
 	} else {
 		const cwd = options.cwd;
 		const githubBranch = options.githubBranch;
+		const gitlabBranch = options.gitlabBranch;
 		const baseContentUrl = options.baseContentUrl;
 		const baseImagesUrl = options.baseImagesUrl;
 		const useYarn = options.useYarn;
@@ -199,7 +201,7 @@ export function publish(options: IPublishOptions = {}): Promise<any> {
 		promise = versionBump(options.cwd, options.version, options.commitMessage)
 			.then(() => tmpName())
 			.then(packagePath =>
-				pack({ packagePath, cwd, githubBranch, baseContentUrl, baseImagesUrl, useYarn, ignoreFile, web })
+				pack({ packagePath, cwd, githubBranch, gitlabBranch, baseContentUrl, baseImagesUrl, useYarn, ignoreFile, web })
 			);
 	}
 

--- a/src/test/fixtures/readme/readme.gitlab.branch.main.expected.md
+++ b/src/test/fixtures/readme/readme.gitlab.branch.main.expected.md
@@ -1,0 +1,48 @@
+# README
+
+>**Important:** Once installed the checker will only update if you add the setting `"spellMD.enable": true` to your `.vscode\settings.json` file.
+
+This README covers off:
+* [Functionality](#functionality)
+* [Install](#install)
+* [Run and Configure](#run-and-configure)
+* [Known Issues/Bugs](#known-issuesbugs)
+* [Backlog](#backlog)
+* [How to Debug](#how-to-debug)
+
+# Functionality
+
+Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
+
+![Underscores and hovers](https://gitlab.com/username/repository/-/raw/main/images/SpellMDDemo1.gif)
+
+The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
+
+[![Jump to issues](https://gitlab.com/username/repository/-/raw/main/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](https://gitlab.com/username/repository/-/raw/main/images/SpellMDDemo2.gif)](https://gitlab.com/username/repository/-/blob/main/monkey)
+![](https://gitlab.com/username/repository/-/raw/main/images/SpellMDDemo2.gif)
+<img src="https://gitlab.com/username/repository/-/raw/main/images/myImage.gif">
+
+The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
+
+![Add to dictionary](https://gitlab.com/username/repository/-/raw/main/images/SpellMDDemo3.gif)
+
+![issue](https://gitlab.com/username/repository/-/raw/main/issue)
+
+[mono](https://gitlab.com/username/repository/-/blob/main/monkey)
+[not](http://shouldnottouchthis/)
+[Email me](mailto:example@example.com)
+
+# Install
+This extension is published in the VS Code Gallery.  So simply hit 'F1' and type 'ext inst' from there select `SpellMD` and follow instructions.
+
+
+To clone the extension and load locally...
+
+```
+git clone https://github.com/Microsoft/vscode-SpellMD.git
+npm install
+tsc
+```
+
+>**Note:** TypeScript 1.6 or higher is required you can check with `tsc -v` and if you need to upgrade then run `npm install -g typescript`.

--- a/src/test/fixtures/readme/readme.gitlab.branch.override.content.expected.md
+++ b/src/test/fixtures/readme/readme.gitlab.branch.override.content.expected.md
@@ -1,0 +1,48 @@
+# README
+
+>**Important:** Once installed the checker will only update if you add the setting `"spellMD.enable": true` to your `.vscode\settings.json` file.
+
+This README covers off:
+* [Functionality](#functionality)
+* [Install](#install)
+* [Run and Configure](#run-and-configure)
+* [Known Issues/Bugs](#known-issuesbugs)
+* [Backlog](#backlog)
+* [How to Debug](#how-to-debug)
+
+# Functionality
+
+Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
+
+![Underscores and hovers](https://gitlab.com/base/images/SpellMDDemo1.gif)
+
+The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
+
+[![Jump to issues](https://gitlab.com/base/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](https://gitlab.com/base/images/SpellMDDemo2.gif)](https://gitlab.com/base/monkey)
+![](https://gitlab.com/base/images/SpellMDDemo2.gif)
+<img src="https://gitlab.com/base/images/myImage.gif">
+
+The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
+
+![Add to dictionary](https://gitlab.com/base/images/SpellMDDemo3.gif)
+
+![issue](https://gitlab.com/base/issue)
+
+[mono](https://gitlab.com/base/monkey)
+[not](http://shouldnottouchthis/)
+[Email me](mailto:example@example.com)
+
+# Install
+This extension is published in the VS Code Gallery.  So simply hit 'F1' and type 'ext inst' from there select `SpellMD` and follow instructions.
+
+
+To clone the extension and load locally...
+
+```
+git clone https://github.com/Microsoft/vscode-SpellMD.git
+npm install
+tsc
+```
+
+>**Note:** TypeScript 1.6 or higher is required you can check with `tsc -v` and if you need to upgrade then run `npm install -g typescript`.

--- a/src/test/fixtures/readme/readme.gitlab.branch.override.images.expected.md
+++ b/src/test/fixtures/readme/readme.gitlab.branch.override.images.expected.md
@@ -1,0 +1,48 @@
+# README
+
+>**Important:** Once installed the checker will only update if you add the setting `"spellMD.enable": true` to your `.vscode\settings.json` file.
+
+This README covers off:
+* [Functionality](#functionality)
+* [Install](#install)
+* [Run and Configure](#run-and-configure)
+* [Known Issues/Bugs](#known-issuesbugs)
+* [Backlog](#backlog)
+* [How to Debug](#how-to-debug)
+
+# Functionality
+
+Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
+
+![Underscores and hovers](https://gitlab.com/base/images/SpellMDDemo1.gif)
+
+The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
+
+[![Jump to issues](https://gitlab.com/base/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](https://gitlab.com/base/images/SpellMDDemo2.gif)](https://gitlab.com/username/repository/-/blob/main/monkey)
+![](https://gitlab.com/base/images/SpellMDDemo2.gif)
+<img src="https://gitlab.com/base/images/myImage.gif">
+
+The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
+
+![Add to dictionary](https://gitlab.com/base/images/SpellMDDemo3.gif)
+
+![issue](https://gitlab.com/base/issue)
+
+[mono](https://gitlab.com/username/repository/-/blob/main/monkey)
+[not](http://shouldnottouchthis/)
+[Email me](mailto:example@example.com)
+
+# Install
+This extension is published in the VS Code Gallery.  So simply hit 'F1' and type 'ext inst' from there select `SpellMD` and follow instructions.
+
+
+To clone the extension and load locally...
+
+```
+git clone https://github.com/Microsoft/vscode-SpellMD.git
+npm install
+tsc
+```
+
+>**Note:** TypeScript 1.6 or higher is required you can check with `tsc -v` and if you need to upgrade then run `npm install -g typescript`.

--- a/src/test/fixtures/readme/readme.gitlab.default.md
+++ b/src/test/fixtures/readme/readme.gitlab.default.md
@@ -1,0 +1,48 @@
+# README
+
+>**Important:** Once installed the checker will only update if you add the setting `"spellMD.enable": true` to your `.vscode\settings.json` file.
+
+This README covers off:
+* [Functionality](#functionality)
+* [Install](#install)
+* [Run and Configure](#run-and-configure)
+* [Known Issues/Bugs](#known-issuesbugs)
+* [Backlog](#backlog)
+* [How to Debug](#how-to-debug)
+
+# Functionality
+
+Load up a Markdown file and get highlights and hovers for existing issues.  Checking will occur as you type in the document.
+
+![Underscores and hovers](https://gitlab.com/username/repository/-/raw/HEAD/images/SpellMDDemo1.gif)
+
+The status bar lets you quickly navigate to any issue and you can see all positions in the gutter.
+
+[![Jump to issues](https://gitlab.com/username/repository/-/raw/HEAD/images/SpellMDDemo2.gif)](http://shouldnottouchthis/)
+[![Jump to issues](https://gitlab.com/username/repository/-/raw/HEAD/images/SpellMDDemo2.gif)](https://gitlab.com/username/repository/-/blob/HEAD/monkey)
+![](https://gitlab.com/username/repository/-/raw/HEAD/images/SpellMDDemo2.gif)
+<img src="https://gitlab.com/username/repository/-/raw/HEAD/images/myImage.gif">
+
+The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
+
+![Add to dictionary](https://gitlab.com/username/repository/-/raw/HEAD/images/SpellMDDemo3.gif)
+
+![issue](https://gitlab.com/username/repository/-/raw/HEAD/issue)
+
+[mono](https://gitlab.com/username/repository/-/blob/HEAD/monkey)
+[not](http://shouldnottouchthis/)
+[Email me](mailto:example@example.com)
+
+# Install
+This extension is published in the VS Code Gallery.  So simply hit 'F1' and type 'ext inst' from there select `SpellMD` and follow instructions.
+
+
+To clone the extension and load locally...
+
+```
+git clone https://github.com/Microsoft/vscode-SpellMD.git
+npm install
+tsc
+```
+
+>**Note:** TypeScript 1.6 or higher is required you can check with `tsc -v` and if you need to upgrade then run `npm install -g typescript`.

--- a/src/test/fixtures/readme/readme.gitlab.expected.md
+++ b/src/test/fixtures/readme/readme.gitlab.expected.md
@@ -1,0 +1,15 @@
+# Replace
+
+[#8](https://gitlab.com/username/repository/-/issues/8)
+
+* Some issue in same repository: [#7](https://gitlab.com/username/repository/-/issues/7)
+* Some issue in other repository: [other/repositoryName#8](https://gitlab.com/other/repositoryName/-/issues/8)
+* Some issue in other repository with fancy name: [my_user-name/my-rep_o12#6](https://gitlab.com/my_user-name/my-rep_o12/-/issues/6)
+
+# Do not touch this:
+ * username#4 (no valid gitlab link)
+ * /#7
+ * foo/$234/#7
+ * [#7](http://shouldnottouchthis/)
+ * [other/repositoryName#8](http://shouldnottouchthis/)
+ * [Email me](MAILTO:example@example.com)

--- a/src/test/fixtures/readme/readme.gitlab.md
+++ b/src/test/fixtures/readme/readme.gitlab.md
@@ -1,0 +1,15 @@
+# Replace
+
+#8
+
+* Some issue in same repository: #7
+* Some issue in other repository: other/repositoryName#8
+* Some issue in other repository with fancy name: my_user-name/my-rep_o12#6
+
+# Do not touch this:
+ * username#4 (no valid gitlab link)
+ * /#7
+ * foo/$234/#7
+ * [#7](http://shouldnottouchthis/)
+ * [other/repositoryName#8](http://shouldnottouchthis/)
+ * [Email me](MAILTO:example@example.com)

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -2011,6 +2011,33 @@ describe('MarkdownProcessor', () => {
 			});
 	});
 
+	it('should infer baseContentUrl if its a gitlab repo (short format)', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'gitlab:username/repository',
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, {});
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md'),
+		};
+
+		return processor
+			.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.gitlab.default.md'), 'utf8').then(expected => {
+					assert.equal(actual, expected);
+				});
+			});
+	});
+
 	it('should replace relative links with GitLab URLs while respecting gitlabBranch', () => {
 		const manifest = {
 			name: 'test',

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1930,6 +1930,150 @@ describe('MarkdownProcessor', () => {
 			});
 	});
 
+	it('should infer baseContentUrl if its a gitlab repo', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://gitlab.com/username/repository',
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, {});
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md'),
+		};
+
+		return processor
+			.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.gitlab.default.md'), 'utf8').then(expected => {
+					assert.equal(actual, expected);
+				});
+			});
+	});
+
+	it('should infer baseContentUrl if its a gitlab repo (.git)', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://gitlab.com/username/repository.git',
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, {});
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md'),
+		};
+
+		return processor
+			.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.gitlab.default.md'), 'utf8').then(expected => {
+					assert.equal(actual, expected);
+				});
+			});
+	});
+
+	it('should replace relative links with GitLab URLs while respecting gitlabBranch', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://gitlab.com/username/repository',
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, {
+			gitlabBranch: 'main',
+		});
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md'),
+		};
+
+		return processor
+			.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.gitlab.branch.main.expected.md'), 'utf8').then(expected => {
+					assert.equal(actual, expected);
+				});
+			});
+	});
+
+	it('should override image URLs with baseImagesUrl while also respecting gitlabBranch', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://gitlab.com/username/repository',
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, {
+			gitlabBranch: 'main',
+			// Override image relative links to point to different base URL
+			baseImagesUrl: 'https://gitlab.com/base',
+		});
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md'),
+		};
+
+		return processor
+			.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.gitlab.branch.override.images.expected.md'), 'utf8').then(expected => {
+					assert.equal(actual, expected);
+				});
+			});
+	});
+
+	it('should override gitlabBranch setting with baseContentUrl', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://gitlab.com/username/repository',
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, {
+			gitlabBranch: 'main',
+			baseContentUrl: 'https://gitlab.com/base',
+		});
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md'),
+		};
+
+		return processor
+			.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.gitlab.branch.override.content.expected.md'), 'utf8').then(expected => {
+					assert.equal(actual, expected);
+				});
+			});
+	});
+
 	it('should replace img urls with baseImagesUrl', () => {
 		const manifest = {
 			name: 'test',
@@ -2037,6 +2181,60 @@ describe('MarkdownProcessor', () => {
 			.then(file => read(file))
 			.then(actual => {
 				return readFile(path.join(root, 'readme.github.md'), 'utf8').then(expected => {
+					assert.equal(actual, expected);
+				});
+			});
+	});
+
+	it('should replace issue links with urls if its a gitlab repo.', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://gitlab.com/username/repository.git',
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, {});
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.gitlab.md'),
+		};
+
+		return processor
+			.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.gitlab.expected.md'), 'utf8').then(expected => {
+					assert.equal(actual, expected);
+				});
+			});
+	});
+
+	it('should not replace issue links with urls if its a gitlab repo but issue link expansion is disabled.', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: 'https://gitlab.com/username/repository.git',
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, { gitLabIssueLinking: false });
+		const readme = {
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.gitlab.md'),
+		};
+
+		return processor
+			.onFile(readme)
+			.then(file => read(file))
+			.then(actual => {
+				return readFile(path.join(root, 'readme.gitlab.md'), 'utf8').then(expected => {
 					assert.equal(actual, expected);
 				});
 			});


### PR DESCRIPTION
This MR:

- Adds support for recognizing GitLab.com repositories and correctly inferring `baseContentUrl` and `baseImagesUrl`. 
- Adds support for recognizing and replacing GitLab issue references with the correct URL

Caveats:

- GitLab allows subgroups, so `https://gitlab.com/foo/bar/baz.git` could be a valid repository.
- GitLab is adding a [special references](https://docs.gitlab.com/ee/user/markdown.html#special-gitlab-references) syntax, so in the future, issue references may also come in the form `[issue:123]`

I just duplicated the flags `--githubBranch` and `--no-gitHubIssueLinking` and associated code paths, `s/github/gitlab/`. It may be better to rename the flags instead of duplicating them, but I couldn't think of a good name for "Hosted Git server branch name". I thought about sharing `--githubBranch`, but IMO that would be bad UX (for `--githubBranch` to be relevant to GitLab repos).