### PR TITLE
fix: Missing error response handling

### DIFF
--- a/src/publicgalleryapi.ts
+++ b/src/publicgalleryapi.ts
@@ -54,6 +54,10 @@ export class PublicGalleryAPI {
 		});
 		const raw = JSON.parse(await res.readBody());
 
+		if (raw.errorCode !== undefined) {
+			throw new Error(raw.message);
+		}
+
 		return ContractSerializer.deserialize(raw.results[0].extensions, TypeInfo.PublishedExtension, false, false);
 	}
 


### PR DESCRIPTION
In case of an invalid extension identifier, the error message from the backend is now properly displayed in the console:

> ERROR  The query supplied was not valid, one of the filters contained an error. The fully qualified name MUST contain a '.' between the publisher and extension names.

![image](https://user-images.githubusercontent.com/1658949/117021860-058e2280-acf8-11eb-939f-36ff92a3777b.png)


Fixes #563