### PR TITLE
add remote-menu tag

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -361,7 +361,16 @@ export class TagsProcessor extends BaseProcessor {
 		const keywords = this.manifest.keywords || [];
 		const contributes = this.manifest.contributes;
 		const activationEvents = this.manifest.activationEvents || [];
-		const doesContribute = name => contributes && contributes[name] && contributes[name].length > 0;
+		const doesContribute = (...properties: string[]) => {
+			let obj = contributes;
+			for (const property of properties) {
+				if (!obj) {
+					return false;
+				}
+				obj = obj[property];
+			}
+			return obj && obj.length > 0;
+		};
 
 		const colorThemes = doesContribute('themes') ? ['theme', 'color-theme'] : [];
 		const iconThemes = doesContribute('iconThemes') ? ['theme', 'icon-theme'] : [];
@@ -370,6 +379,7 @@ export class TagsProcessor extends BaseProcessor {
 		const keybindings = doesContribute('keybindings') ? ['keybindings'] : [];
 		const debuggers = doesContribute('debuggers') ? ['debuggers'] : [];
 		const json = doesContribute('jsonValidation') ? ['json'] : [];
+		const remoteMenu = doesContribute('menus', 'statusBar/remoteIndicator') ? ['remote-menu'] : [];
 
 		const localizationContributions = ((contributes && contributes['localizations']) || []).reduce(
 			(r, l) => [...r, `lp-${l.languageId}`, ...toLanguagePackTags(l.translations, l.languageId)],
@@ -406,6 +416,7 @@ export class TagsProcessor extends BaseProcessor {
 			...keybindings,
 			...debuggers,
 			...json,
+			...remoteMenu,
 			...localizationContributions,
 			...languageContributions,
 			...languageActivations,

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -945,6 +945,31 @@ describe('toVsixManifest', () => {
 			});
 	});
 
+	it('should automatically add remote-menu tag', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			engines: Object.create(null),
+			contributes: {
+				menus: {
+					'statusBar/remoteIndicator': [
+						{
+							command: 'remote-wsl.newWindow',
+						},
+					],
+				},
+			},
+		};
+
+		return _toVsixManifest(manifest, [])
+			.then(parseXmlManifest)
+			.then(result => {
+				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
+				assert(tags.some(tag => tag === 'remote-menu'));
+			});
+	});
+
 	it('should automatically add language tag with activationEvent', () => {
 		const manifest = {
 			name: 'test',


### PR DESCRIPTION
I want to use the `remote-menu` to get a list of extensions that contribute to the remote indicator menu