### PR TITLE
fix .vscodeignore not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vsce",
-	"version": "1.92.0",
+	"version": "1.92.1",
 	"description": "VSCode Extension Manager",
 	"repository": {
 		"type": "git",

--- a/src/package.ts
+++ b/src/package.ts
@@ -1072,7 +1072,8 @@ function collectAllFiles(cwd: string, useYarn?: boolean, dependencyEntryPoints?:
 
 async function readIgnoreFile(cwd: string, ignoreFile?: string): Promise<string> {
 	try {
-		return await readFile(ignoreFile ? ignoreFile : path.join(cwd, '.vscodeignore'), 'utf8');
+		// https://www.npmjs.com/package/ignore
+		return fs.readFileSync(ignoreFile ? ignoreFile : path.join(cwd, '.vscodeignore')).toString();
 	} catch (err) {
 		if (err.code !== 'ENOENT' || ignoreFile) {
 			throw err;


### PR DESCRIPTION
#576 

Update ignore usage:

```js
ignore()
.add(fs.readFileSync(filenameOfGitignore).toString())
.filter(filenames)
```

see: https://www.npmjs.com/package/ignore