### PR TITLE
Update `azure-devops-node-api` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"node": ">= 10"
 	},
 	"dependencies": {
-		"azure-devops-node-api": "^10.2.2",
+		"azure-devops-node-api": "^11.0.1",
 		"chalk": "^2.4.2",
 		"cheerio": "^1.0.0-rc.9",
 		"commander": "^6.1.0",


### PR DESCRIPTION
The PR updates version of the `azure-devops-node-api` dependecy to `11.0.1` to pull in recent changes to remove fake credentials from the readme: https://github.com/microsoft/azure-devops-node-api/pull/453
The fake credentials trigger cred scanner alerts for internal products that depend on `vsce` and thus on `azure-devops-node-api` (like GH Codespaces and LiveShare extensions) [[ticket](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1323550/)].