### PR TITLE
Fixed an issue where search returns ADO and VSIDE

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -3,12 +3,18 @@ import { ExtensionQueryFilterType, ExtensionQueryFlags } from 'azure-devops-node
 import { tableView, wordTrim } from './viewutils';
 
 const pageSize = 100;
+const installationTarget = 'Microsoft.VisualStudio.Code';
+const excludeFlags = '37888'; //Value to exclude un-published, locked or hidden extensions
 
 export async function search(searchText: string, json: boolean = false): Promise<any> {
 	const api = getPublicGalleryAPI();
 	const results = await api.extensionQuery({
 		pageSize,
-		criteria: [{ filterType: ExtensionQueryFilterType.SearchText, value: searchText }],
+		criteria: [
+			{ filterType: ExtensionQueryFilterType.SearchText, value: searchText },
+			{ filterType: ExtensionQueryFilterType.InstallationTarget, value: installationTarget },
+			{ filterType: ExtensionQueryFilterType.ExcludeWithFlags, value: excludeFlags },
+		],
 		flags: [ExtensionQueryFlags.ExcludeNonValidated, ExtensionQueryFlags.IncludeLatestVersionOnly],
 	});
 


### PR DESCRIPTION
Fixed the issue #605 where search returns ADO, VSIDE, un-published, or locked extensions along with VS Code extensions
