### PR TITLE
Add open.vscode.dev as trusted svg source

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -251,6 +251,7 @@ const TrustedSVGSources = [
 	'vsmarketplacebadge.apphb.com',
 	'www.bithound.io',
 	'www.versioneye.com',
+	'open.vscode.dev'
 ];
 
 function isGitHubRepository(repository: string | null): boolean {


### PR DESCRIPTION
Add open.vscode.dev as trusted svg source. This is for `Open in Visual Studio Code` badge.