### PR TITLE
feat: warn users about missing LICENSE

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -856,7 +856,7 @@ class LicenseProcessor extends BaseProcessor {
 		if (!this.didFindLicense) {
 			util.log.warn(`${this.expectedLicenseName} not found`);
 
-			if (!/^y$/i.test(await util.read('Do you want to continue? [Y/n] '))) {
+			if (!/^y$/i.test(await util.read('Do you want to continue? [y/N] '))) {
 				throw new Error('Aborted');
 			}
 		}


### PR DESCRIPTION
## Motivation

Fixes #603 

When the code fails to automatically detect a LICENSE file, it now warns the users if they want to continue.

## Test Plan

Run `vsce package` without a `LICENSE` should generate a warning message.
```bash
# No LICENSE. 
# No 'SEE LICENSE IN term.md'

PS C:\helloworld> vsce package
Executing prepublish script 'npm run vscode:prepublish'...

> helloworld@0.0.1 vscode:prepublish
> npm run compile


> helloworld@0.0.1 compile
> tsc -p ./

 WARNING LICENSE.md or LICENSE.txt not found
Do you want to continue? [Y/N]

# No LICENSE. 
# Has 'SEE LICENSE IN term.md'

PS C:\helloworld> vsce package
Executing prepublish script 'npm run vscode:prepublish'...

> helloworld@0.0.1 vscode:prepublish
> npm run compile


> helloworld@0.0.1 compile
> tsc -p ./

 WARNING  term.md not found
Do you want to continue? [Y/N]

# Has LICENSE. 
# Has 'SEE LICENSE IN term.md'

PS C:\helloworld> vsce package
Executing prepublish script 'npm run vscode:prepublish'...

> helloworld@0.0.1 vscode:prepublish
> npm run compile


> helloworld@0.0.1 compile
> tsc -p ./

 WARNING  term.md not found
Do you want to continue? [Y/N]
```