### PR TITLE
package: Introduce `list-targets` flag

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,7 @@ module.exports = function (argv: string[]): void {
 		.description('Packages an extension')
 		.option('-o, --out <path>', 'Output .vsix extension file to <path> location (defaults to <name>-<version>.vsix)')
 		.option('-t, --target <target>', 'Target architecture')
+		.option('--list-targets', 'List supported target architectures')
 		.option('-m, --message <commit message>', 'Commit message used when calling `npm version`.')
 		.option('--no-git-tag-version', 'Do not create a version commit and tag when calling `npm version`.')
 		.option(
@@ -102,6 +103,7 @@ module.exports = function (argv: string[]): void {
 				{
 					out,
 					target,
+					listTargets,
 					message,
 					gitTagVersion,
 					githubBranch,
@@ -119,6 +121,7 @@ module.exports = function (argv: string[]): void {
 						packagePath: out,
 						version,
 						target,
+						listTargets,
 						commitMessage: message,
 						gitTagVersion,
 						githubBranch,

--- a/src/package.ts
+++ b/src/package.ts
@@ -85,6 +85,7 @@ export interface IPackageOptions {
 	readonly packagePath?: string;
 	readonly version?: string;
 	readonly target?: string;
+	readonly listTargets?: boolean;
 	readonly commitMessage?: string;
 	readonly gitTagVersion?: boolean;
 	readonly cwd?: string;
@@ -1434,6 +1435,10 @@ export async function pack(options: IPackageOptions = {}): Promise<IPackageResul
 }
 
 export async function packageCommand(options: IPackageOptions = {}): Promise<any> {
+	if (options.listTargets) {
+		return printTargets();
+	}
+
 	await versionBump(options.cwd, options.version, options.commitMessage, options.gitTagVersion);
 
 	const { packagePath, files } = await pack(options);
@@ -1451,6 +1456,12 @@ export async function packageCommand(options: IPackageOptions = {}): Promise<any
 	}
 
 	util.log.done(`Packaged: ${packagePath} (${files.length} files, ${size}${unit})`);
+}
+
+function printTargets(): Promise<any> {
+	return new Promise(() => {
+		Targets.forEach(target => console.log(`${target}`));
+	});
 }
 
 /**


### PR DESCRIPTION
This is one way of addressing some problems outlined in https://github.com/microsoft/vscode-vsce/issues/625 but more importantly make it easier for end-users to see what targets are even supported without having to look into the source code.

I'm half wondering if this is better implemented as a new subcommand? `vsce ls-targets` or `vsce ls-package-targets`, I'm assuming that this would allow easier expansion with more flags later. I imagine that a `--json` flag might be useful here to change the shell-friendly new-line-separated output to JSON.