### PR TITLE
Fix broken Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:12-alpine
 WORKDIR /opt/vsce
-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
 RUN npm install
 COPY . .
 RUN npm run compile
 RUN rm package-lock.json tsconfig.json
 VOLUME /workspace
 WORKDIR /workspace
-ENTRYPOINT ["/opt/vsce/out/vsce"]
+ENTRYPOINT ["/opt/vsce/vsce"]


### PR DESCRIPTION
Hi! Thanks for providing the Dockerfile here. I just ran `vsce` for the first time to publish my first Visual Studio Code extension. I needed to fix a couple of things in the Dockerfile though to get it working with my environment:

Building the image using the instructions in the [README](https://github.com/microsoft/vscode-vsce/blob/588ad794e35e912cac5277a39b41b68be6bf2635/README.md#usage-via-docker)
```
$ docker build -t vsce .
```
fails with
```
Step 3/10 : COPY package.json package-lock.json .
When using COPY with more than one source file, the destination must be a directory and end with a /
```
so I just added the `/`.

Then there were issues with the `ENTRYPOINT` when running the container:
```
$ docker run -it vsce --version
docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "/opt/vsce/out/vsce": stat /opt/vsce/out/vsce: no such file or directory: unknown.
ERRO[0001] error waiting for container: context canceled 
```
I just fixed the path `/opt/vsce/vsce`, but I haven't dug any deeper to check if the path is actually supposed to be `/opt/vsce/out/vsce` and there's a better way of fixing this issue.

I'm running Debian buster with
```
$ docker --version
Docker version 20.10.7, build f0df350
```