### PR TITLE
Add `libsecret` to `Dockerfile` and mention the dependency on `README`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:12-alpine
+RUN apk add --update-cache \
+    libsecret \
+  && rm -rf /var/cache/apk/*
 WORKDIR /opt/vsce
 COPY package.json package-lock.json ./
 RUN npm install

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Or simply [Docker](#via-docker).
 
 ### Linux
 
-This project uses [keytar](https://www.npmjs.com/package/keytar) that uses `libsecret`, so you may need to install it before running `vsce`.
+In order to save credentials safely, this project uses [keytar](https://www.npmjs.com/package/keytar) which uses `libsecret`, which you may need to install before publishing extensions. Setting the `VSCE_STORE=file` environment variable will revert back to the file credential store. Using the `VSCE_PAT` environment variable will also avoid using keytar.
 
 Depending on your distribution, you will need to run the following command:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Or simply [Docker](#via-docker).
 
-### On Linux
+### Linux
 
 This project uses [keytar](https://www.npmjs.com/package/keytar) that uses `libsecret`, so you may need to install it before running `vsce`.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@
 
 Or simply [Docker](#via-docker).
 
+### On Linux
+
+This project uses [keytar](https://www.npmjs.com/package/keytar) that uses `libsecret`, so you may need to install it before running `vsce`.
+
+Depending on your distribution, you will need to run the following command:
+
+- Debian/Ubuntu: `sudo apt-get install libsecret-1-dev`
+- Alpine: `apk add libsecret`
+- Red Hat-based: `sudo yum install libsecret-devel`
+- Arch Linux: `sudo pacman -S libsecret`
+
 ## Usage
 
 Install vsce globally:


### PR DESCRIPTION
since the keytar was added as default, libsecret is a dependency

Fixes #645 