### PR TITLE
fix: docker base image needs be at latest `node:14-alpine`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:14-alpine
 RUN apk add --update-cache \
     libsecret \
   && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Hi, I tested use this tools in Docker yesterday and I got the error output: 

``` bash
/opt/vsce/out/package.js:136
    return (translations ?? [])
                          ^

SyntaxError: Unexpected token '?'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/opt/vsce/out/main.js:27:19)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
```

After I read the document and source codes. I found the Node.js version in the `Dockerfile` is not suitable for the requirement in the README file.   
So I updated it from `12` to `14`.

Thanks.