### PR TITLE
fix: only enforce major and minor version of types check

### DIFF
--- a/src/test/validation.test.ts
+++ b/src/test/validation.test.ts
@@ -115,6 +115,7 @@ describe('validateVSCodeTypesCompatibility', () => {
 		validateVSCodeTypesCompatibility('1.30.0', '1.30.0');
 		validateVSCodeTypesCompatibility('1.30.0', '1.20.0');
 		validateVSCodeTypesCompatibility('1.46.0', '1.45.1');
+		validateVSCodeTypesCompatibility('1.45.0', '1.45.1');
 
 		assert.throws(() => validateVSCodeTypesCompatibility('1.30.0', '1.40.0'));
 		assert.throws(() => validateVSCodeTypesCompatibility('1.30.0', '^1.40.0'));

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -50,7 +50,7 @@ export function validateEngineCompatibility(version: string): void {
 /**
  * User shouldn't use a newer version of @types/vscode than the one specified in engines.vscode
  *
- * NOTE: This is enforced at the major and minor level., Since we don't have control over the patch
+ * NOTE: This is enforced at the major and minor level. Since we don't have control over the patch
  * version (it's auto-incremented by DefinitelyTyped), we don't look at the patch version at all.
  */
 export function validateVSCodeTypesCompatibility(engineVersion: string, typeVersion: string): void {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -49,6 +49,9 @@ export function validateEngineCompatibility(version: string): void {
 
 /**
  * User shouldn't use a newer version of @types/vscode than the one specified in engines.vscode
+ *
+ * NOTE: This is enforced at the major and minor level., Since we don't have control over the patch
+ * version (it's auto-incremented by DefinitelyTyped), we don't look at the patch version at all.
  */
 export function validateVSCodeTypesCompatibility(engineVersion: string, typeVersion: string): void {
 	if (engineVersion === '*') {
@@ -78,14 +81,14 @@ export function validateVSCodeTypesCompatibility(engineVersion: string, typeVers
 	// For all `x`, use smallest version for comparison
 	plainEngineVersion = plainEngineVersion.replace(/x/g, '0');
 
-	const [typeMajor, typeMinor, typePatch] = plainTypeVersion.split('.').map(x => {
+	const [typeMajor, typeMinor] = plainTypeVersion.split('.').map(x => {
 		try {
 			return parseInt(x);
 		} catch (err) {
 			return 0;
 		}
 	});
-	const [engineMajor, engineMinor, enginePatch] = plainEngineVersion.split('.').map(x => {
+	const [engineMajor, engineMinor] = plainEngineVersion.split('.').map(x => {
 		try {
 			return parseInt(x);
 		} catch (err) {
@@ -101,9 +104,6 @@ export function validateVSCodeTypesCompatibility(engineVersion: string, typeVers
 		throw error;
 	}
 	if (typeMajor === engineMajor && typeMinor > engineMinor) {
-		throw error;
-	}
-	if (typeMajor === engineMajor && typeMinor === engineMinor && typePatch > enginePatch) {
 		throw error;
 	}
 }


### PR DESCRIPTION
Since we don't have control over the patch version (it's auto-incremented by DefinitelyTyped), we shouldn't look at the patch version at all.