### PR TITLE
feat: sanity check to validate entrypoints

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -938,9 +938,7 @@ class LaunchEntryPointProcessor extends BaseProcessor {
 	async onEnd(): Promise<void> {
 		if (this.entryPoints.size > 0) {
 			const files: string = [...this.entryPoints].join(',\n  ');
-			return Promise.reject(
-				new Error(`Extension entrypoint(s) missing: check files exists and does not match .vscodeignore:\n  ${files}`)
-			);
+			throw new Error(`Extension entrypoint(s) missing. Make sure these files exist and aren't ignored by '.vscodeignore':\n  ${files}`);
 		}
 	}
 }

--- a/src/package.ts
+++ b/src/package.ts
@@ -930,8 +930,7 @@ class LaunchEntryPointProcessor extends BaseProcessor {
 	}
 
 	onFile(file: IFile): Promise<IFile> {
-		const normalizedPath = util.normalize(file.path);
-		this.entryPoints.delete(normalizedPath);
+		this.entryPoints.delete(util.normalize(file.path));
 		return Promise.resolve(file);
 	}
 

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1807,7 +1807,7 @@ describe('LaunchEntryPointProcessor', () => {
 			const message = err.message;
 			didErr = message.includes('entrypoint(s) missing') && message.includes('main.js');
 		}
-		assert.ok(expectedError);
+		assert.ok(didErr);
 	});
 
 	it('should accept manifest if no entrypoints defined', async () => {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1800,7 +1800,7 @@ describe('LaunchEntryPointProcessor', () => {
 			main: 'main.js',
 		});
 		const files = [{ path: 'extension/browser.js', contents: Buffer.from('') }];
-		let expectedError = false;
+		let didErr = false;
 		try {
 			await _toVsixManifest(manifest, files);
 		} catch (err: any) {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1814,7 +1814,6 @@ describe('LaunchEntryPointProcessor', () => {
 		const manifest = createManifest({});
 		const files = [{ path: 'extension/something.js', contents: Buffer.from('') }];
 		await _toVsixManifest(manifest, files);
-		assert.ok(true);
 	});
 });
 describe('ManifestProcessor', () => {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1794,6 +1794,30 @@ describe('toContentTypes', () => {
 	});
 });
 
+describe('LaunchEntryPointProcessor', () => {
+	it('should detect when declared entrypoint is not in package', async () => {
+		const manifest = createManifest({
+			main: 'main.js',
+		});
+		const files = [{ path: 'extension/browser.js', contents: Buffer.from('') }];
+		let expectedError = false;
+		try {
+			await _toVsixManifest(manifest, files);
+		} catch (err: any) {
+			const error = err as Error;
+			expectedError = error?.message.includes('entrypoint(s) missing');
+			expectedError &&= error?.message.includes('main.js');
+		}
+		assert.ok(expectedError);
+	});
+
+	it('should accept manifest if no entrypoints defined', async () => {
+		const manifest = createManifest({});
+		const files = [{ path: 'extension/something.js', contents: Buffer.from('') }];
+		await _toVsixManifest(manifest, files);
+		assert.ok(true);
+	});
+});
 describe('ManifestProcessor', () => {
 	it('should ensure that package.json is writable', async () => {
 		const root = fixture('uuid');

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1804,9 +1804,8 @@ describe('LaunchEntryPointProcessor', () => {
 		try {
 			await _toVsixManifest(manifest, files);
 		} catch (err: any) {
-			const error = err as Error;
-			expectedError = error?.message.includes('entrypoint(s) missing');
-			expectedError &&= error?.message.includes('main.js');
+			const message = err.message;
+			didErr = message.includes('entrypoint(s) missing') && message.includes('main.js');
 		}
 		assert.ok(expectedError);
 	});


### PR DESCRIPTION
Fixes #670

With entrypoints 'main' and browser' it's increasingly possible to not have an entrypoint setup for packaging.  The chances increase since there tends to be a lot of refactoring to support both runtime environments.

This PR adds a quick check via a *Processor class to make sure that any entrypoint declared in the package is actually going to be present in the `extension` folder of the vsix.

Tests consistent with package.test.ts have been added.