### PR TITLE
fix: entrypoint validation without js tag

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -922,11 +922,18 @@ class LaunchEntryPointProcessor extends BaseProcessor {
 	constructor(manifest: Manifest) {
 		super(manifest);
 		if (manifest.main) {
-			this.entryPoints.add(util.normalize(path.join('extension', manifest.main)));
+			this.entryPoints.add(util.normalize(path.join('extension', this.appendJSExt(manifest.main))));
 		}
 		if (manifest.browser) {
-			this.entryPoints.add(util.normalize(path.join('extension', manifest.browser)));
+			this.entryPoints.add(util.normalize(path.join('extension', this.appendJSExt(manifest.browser))));
 		}
+	}
+
+	appendJSExt(filePath: string): string {
+		if (filePath.endsWith('.js')) {
+			return filePath;
+		}
+		return filePath + '.js';
 	}
 
 	onFile(file: IFile): Promise<IFile> {
@@ -937,7 +944,9 @@ class LaunchEntryPointProcessor extends BaseProcessor {
 	async onEnd(): Promise<void> {
 		if (this.entryPoints.size > 0) {
 			const files: string = [...this.entryPoints].join(',\n  ');
-			throw new Error(`Extension entrypoint(s) missing. Make sure these files exist and aren't ignored by '.vscodeignore':\n  ${files}`);
+			throw new Error(
+				`Extension entrypoint(s) missing. Make sure these files exist and aren't ignored by '.vscodeignore':\n  ${files}`
+			);
 		}
 	}
 }

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1794,7 +1794,7 @@ describe('toContentTypes', () => {
 	});
 });
 
-describe.only('LaunchEntryPointProcessor', () => {
+describe('LaunchEntryPointProcessor', () => {
 	it('should detect when declared entrypoint is not in package', async () => {
 		const manifest = createManifest({
 			main: 'main.js',

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1794,7 +1794,7 @@ describe('toContentTypes', () => {
 	});
 });
 
-describe('LaunchEntryPointProcessor', () => {
+describe.only('LaunchEntryPointProcessor', () => {
 	it('should detect when declared entrypoint is not in package', async () => {
 		const manifest = createManifest({
 			main: 'main.js',
@@ -1806,6 +1806,23 @@ describe('LaunchEntryPointProcessor', () => {
 		} catch (err: any) {
 			const message = err.message;
 			didErr = message.includes('entrypoint(s) missing') && message.includes('main.js');
+		}
+		assert.ok(didErr);
+	});
+
+	it('should work even if .js extension is not mentioned', async () => {
+		const manifest = createManifest({
+			main: './out/src/extension',
+		});
+		const files = [{ path: 'extension/out/src/extension.js', contents: Buffer.from('') }];
+
+		let didErr = false;
+
+		try {
+			await _toVsixManifest(manifest, files);
+			didErr = true;
+		} catch (err: any) {
+			didErr = false;
 		}
 		assert.ok(didErr);
 	});

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1796,35 +1796,25 @@ describe('toContentTypes', () => {
 
 describe('LaunchEntryPointProcessor', () => {
 	it('should detect when declared entrypoint is not in package', async () => {
-		const manifest = createManifest({
-			main: 'main.js',
-		});
+		const manifest = createManifest({ main: 'main.js' });
 		const files = [{ path: 'extension/browser.js', contents: Buffer.from('') }];
+
 		let didErr = false;
+
 		try {
 			await _toVsixManifest(manifest, files);
 		} catch (err: any) {
 			const message = err.message;
 			didErr = message.includes('entrypoint(s) missing') && message.includes('main.js');
 		}
+
 		assert.ok(didErr);
 	});
 
-	it('should work even if .js extension is not mentioned', async () => {
-		const manifest = createManifest({
-			main: './out/src/extension',
-		});
+	it('should work even if .js extension is not used', async () => {
+		const manifest = createManifest({ main: 'out/src/extension' });
 		const files = [{ path: 'extension/out/src/extension.js', contents: Buffer.from('') }];
-
-		let didErr = false;
-
-		try {
-			await _toVsixManifest(manifest, files);
-			didErr = true;
-		} catch (err: any) {
-			didErr = false;
-		}
-		assert.ok(didErr);
+		await _toVsixManifest(manifest, files);
 	});
 
 	it('should accept manifest if no entrypoints defined', async () => {


### PR DESCRIPTION
Fixes #675 

Validation of entry points is added In the last release #669. But there is a small edge case. 

Writing `.js` file extension in node environment is optional.  
People usually write `main: "out/extension"` which is actually `"out/extension.js"`.

So, the below condition will fail.
https://github.com/microsoft/vscode-vsce/blob/dc68cc89fe9c7ac0c690a5bc01175756c431e781/src/package.ts#L933

I fixed the bug and also added a test case for this situation in this PR.