### PR TITLE
feat: add readme path override

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -96,6 +96,7 @@ module.exports = function (argv: string[]): void {
 		.option('--no-rewrite-relative-links', 'Skip rewriting relative links.')
 		.option('--baseContentUrl <url>', 'Prepend all relative links in README.md with this url.')
 		.option('--baseImagesUrl <url>', 'Prepend all relative image links in README.md with this url.')
+		.option('--readmePath <path>', 'Set the path or readme file, by default use README.md')
 		.option('--yarn', 'Use yarn instead of npm (default inferred from presence of yarn.lock or .yarnrc)')
 		.option('--no-yarn', 'Use npm instead of yarn (default inferred from lack of yarn.lock or .yarnrc)')
 		.option('--ignoreFile <path>', 'Indicate alternative .vscodeignore')
@@ -119,6 +120,7 @@ module.exports = function (argv: string[]): void {
 					rewriteRelativeLinks,
 					baseContentUrl,
 					baseImagesUrl,
+					readmePath,
 					yarn,
 					ignoreFile,
 					gitHubIssueLinking,
@@ -142,6 +144,7 @@ module.exports = function (argv: string[]): void {
 						rewriteRelativeLinks,
 						baseContentUrl,
 						baseImagesUrl,
+						readmePath,
 						useYarn: yarn,
 						ignoreFile,
 						gitHubIssueLinking,
@@ -180,6 +183,7 @@ module.exports = function (argv: string[]): void {
 		)
 		.option('--baseContentUrl <url>', 'Prepend all relative links in README.md with this url.')
 		.option('--baseImagesUrl <url>', 'Prepend all relative image links in README.md with this url.')
+		.option('--readmePath <path>', 'Set the path or readme file, by default use README.md')
 		.option('--yarn', 'Use yarn instead of npm (default inferred from presence of yarn.lock or .yarnrc)')
 		.option('--no-yarn', 'Use npm instead of yarn (default inferred from lack of yarn.lock or .yarnrc)')
 		.option('--noVerify')
@@ -202,6 +206,7 @@ module.exports = function (argv: string[]): void {
 					gitlabBranch,
 					baseContentUrl,
 					baseImagesUrl,
+					readmePath,
 					yarn,
 					noVerify,
 					ignoreFile,

--- a/src/package.ts
+++ b/src/package.ts
@@ -79,6 +79,7 @@ export interface IPackageOptions {
 	readonly rewriteRelativeLinks?: boolean;
 	readonly baseContentUrl?: string;
 	readonly baseImagesUrl?: string;
+	readonly readmePath?: string;
 	readonly useYarn?: boolean;
 	readonly dependencyEntryPoints?: string[];
 	readonly ignoreFile?: string;
@@ -851,7 +852,7 @@ export class MarkdownProcessor extends BaseProcessor {
 
 export class ReadmeProcessor extends MarkdownProcessor {
 	constructor(manifest: Manifest, options: IPackageOptions = {}) {
-		super(manifest, 'README.md', /^extension\/readme.md$/i, 'Microsoft.VisualStudio.Services.Content.Details', options);
+		super(manifest, options.readmePath || 'README.md', /^extension\/readme.md$/i, 'Microsoft.VisualStudio.Services.Content.Details', options);
 	}
 }
 export class ChangelogProcessor extends MarkdownProcessor {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -24,6 +24,7 @@ export interface IPublishOptions {
 	readonly gitlabBranch?: string;
 	readonly baseContentUrl?: string;
 	readonly baseImagesUrl?: string;
+	readonly readmePath?: string;
 	readonly useYarn?: boolean;
 	readonly dependencyEntryPoints?: string[];
 	readonly ignoreFile?: string;


### PR DESCRIPTION
need the support of use different readme file when you pack\publish an extension 
i saw that there was an issue that close because it was out of scope, and i need it because my readme contains svgs, and it was very easy to add this support 
https://github.com/microsoft/vscode-vsce/issues/210