### PR TITLE
build(release): improve release logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
 				"@types/xml2js": "^0.4.4",
 				"@types/yauzl": "^2.9.2",
 				"@types/yazl": "^2.4.2",
+				"conventional-changelog-conventionalcommits": "^4.6.3",
 				"husky": "^7.0.4",
 				"mocha": "^9.2.0",
 				"npm-run-all": "^4.1.5",
@@ -1774,9 +1775,9 @@
 			}
 		},
 		"node_modules/conventional-changelog-conventionalcommits": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
-			"integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+			"integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
 			"dev": true,
 			"dependencies": {
 				"compare-func": "^2.0.0",
@@ -10507,9 +10508,9 @@
 			}
 		},
 		"conventional-changelog-conventionalcommits": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
-			"integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+			"integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vsce",
-	"version": "0.0.0",
+	"version": "0.0.0-development",
 	"description": "VSCode Extension Manager",
 	"repository": {
 		"type": "git",
@@ -74,6 +74,7 @@
 		"@types/xml2js": "^0.4.4",
 		"@types/yauzl": "^2.9.2",
 		"@types/yazl": "^2.4.2",
+		"conventional-changelog-conventionalcommits": "^4.6.3",
 		"husky": "^7.0.4",
 		"mocha": "^9.2.0",
 		"npm-run-all": "^4.1.5",
@@ -96,11 +97,6 @@
 		"printWidth": 120,
 		"singleQuote": true,
 		"arrowParens": "avoid"
-	},
-	"release": {
-		"branches": [
-			"main"
-		]
 	},
 	"commitlint": {
 		"extends": [

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,73 @@
+module.exports = {
+	branches: ['main'],
+	preset: 'conventionalcommits',
+	plugins: [
+		[
+			'@semantic-release/commit-analyzer',
+			{
+				releaseRules: [
+					{
+						type: 'perf',
+						release: 'patch',
+					},
+					{
+						type: 'refactor',
+						release: 'patch',
+					},
+					{
+						type: 'build',
+						scope: 'deps',
+						release: 'patch',
+					},
+				],
+			},
+		],
+		[
+			'@semantic-release/release-notes-generator',
+			{
+				presetConfig: {
+					types: [
+						{
+							type: 'feat',
+							section: 'Features',
+						},
+						{
+							type: 'fix',
+							section: 'Bug Fixes',
+						},
+						{
+							type: 'perf',
+							section: 'Performance Improvements',
+						},
+						{
+							type: 'revert',
+							section: 'Reverts',
+						},
+						{
+							type: 'refactor',
+							section: 'Code Refactoring',
+						},
+						{
+							type: 'build',
+							scope: 'deps',
+							section: 'Dependencies',
+						},
+					],
+				},
+			},
+		],
+		[
+			'@semantic-release/npm',
+			{
+				tarballDir: '.',
+			},
+		],
+		[
+			'@semantic-release/github',
+			{
+				assets: '*.tgz',
+				addReleases: 'bottom',
+			},
+		],
+	],
+};


### PR DESCRIPTION
Changing the preset to `conventionalcommits` ensures that the commit message matches the current specification of Conventional Commits. Otherwise, the default is `angular` which is the AngularJS style. I always wanted that semantic-release shipped that by default, but unfortunately they don't have time to merge [my PR](https://github.com/semantic-release/semantic-release/pull/1836).

It also allows to use things like `fix!: drop support for something` to indicate that the commit is a breaking change.

I also configured semantic-release with some things that I judge to be more optimal, like triggering releases when a production dependency gets updated, or a refactoring or performance improvement gets merged. I found many versions released with non helpful changelogs because of this, like [v2.7.0](https://github.com/microsoft/vscode-vsce/releases/tag/v2.6.4), and [v2.6.4](https://github.com/microsoft/vscode-vsce/releases/tag/v2.7.0).

It also reduces the clutter from the changelog messages by skipping the update of development dependencies.

To finalize, the new configuration improves the GitHub Releases, since they now will get the npm `.tgz` files as assets and there will be a link to the npmjs page of the release (like [here](https://github.com/felipecrs/semantic-release-vsce/releases/tag/v5.0.11#:~:text=This%20release%20is%20also%20available%20on%3A)).

I hope you like it! :)
