### PR TITLE
feat: Search command improvements

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -282,9 +282,10 @@ module.exports = function (argv: string[]): void {
 	program
 		.command('search <text>')
 		.option('--json', 'Output result in json format', false)
+		.option('--stats', 'Shows the extension rating and download counts', false)
 		.option('-p, --pagesize [value]', 'Number of results to return', '100')
 		.description('search extension gallery')
-		.action((text, { json, pagesize }) => main(search(text, json, parseInt(pagesize))));
+		.action((text, { json, pagesize, stats }) => main(search(text, json, parseInt(pagesize), stats)));
 
 	program.on('command:*', ([cmd]: string) => {
 		if (cmd === 'create-publisher') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { getLatestVersion } from './npm';
 import { CancellationToken, log } from './util';
 import * as semver from 'semver';
 import { isatty } from 'tty';
+
 const pkg = require('../package.json');
 
 function fatal(message: any, ...args: any[]): void {
@@ -281,8 +282,9 @@ module.exports = function (argv: string[]): void {
 	program
 		.command('search <text>')
 		.option('--json', 'Output result in json format', false)
+		.option('-p, --pagesize [value]', 'Number of results to return', '100')
 		.description('search extension gallery')
-		.action((text, { json }) => main(search(text, json)));
+		.action((text, { json, pagesize }) => main(search(text, json, parseInt(pagesize))));
 
 	program.on('command:*', ([cmd]: string) => {
 		if (cmd === 'create-publisher') {

--- a/src/search.ts
+++ b/src/search.ts
@@ -40,9 +40,10 @@ export async function search(
 				`Search results:`,
 				'',
 				...tableView([
-					['<ExtensionId>', '<Name>', '<Installs>', '<Rating>'],
-					...results.map(({ publisher: { publisherName }, extensionName, displayName, statistics }) => [
-						publisherName + '.' + extensionName,
+					['<ExtensionId>', '<Publisher>', '<Name>', '<Installs>', '<Rating>'],
+					...results.map(({ publisher, extensionName, displayName, statistics }) => [
+						publisher.publisherName + '.' + extensionName,
+						publisher.displayName,
 						wordTrim(displayName || '', 25),
 						getStats(statistics!),
 					]),

--- a/src/search.ts
+++ b/src/search.ts
@@ -5,8 +5,6 @@ import {
 	PublishedExtension,
 } from 'azure-devops-node-api/interfaces/GalleryInterfaces';
 import { tableView, wordTrim } from './viewutils';
-
-const pageSize = 100;
 const installationTarget = 'Microsoft.VisualStudio.Code';
 const excludeFlags = '37888'; //Value to exclude un-published, locked or hidden extensions
 
@@ -14,7 +12,7 @@ interface VSCodePublishedExtension extends PublishedExtension {
 	publisher: { displayName: string; publisherName: string };
 }
 
-export async function search(searchText: string, json: boolean = false): Promise<any> {
+export async function search(searchText: string, json: boolean = false, pageSize: number = 10): Promise<any> {
 	const api = getPublicGalleryAPI();
 	const results = (await api.extensionQuery({
 		pageSize,
@@ -41,9 +39,10 @@ export async function search(searchText: string, json: boolean = false): Promise
 			`Search results:`,
 			'',
 			...tableView([
-				['<ExtensionId>', '<Description>'],
-				...results.map(({ publisher: { publisherName }, extensionName, shortDescription }) => [
+				['<ExtensionId>', '<Name>', '<Description>'],
+				...results.map(({ publisher: { publisherName }, extensionName, displayName, shortDescription }) => [
 					publisherName + '.' + extensionName,
+					displayName || '',
 					(shortDescription || '').replace(/\n|\r|\t/g, ' '),
 				]),
 			]),

--- a/src/search.ts
+++ b/src/search.ts
@@ -3,16 +3,22 @@ import {
 	ExtensionQueryFilterType,
 	ExtensionQueryFlags,
 	PublishedExtension,
+	ExtensionStatistic,
 } from 'azure-devops-node-api/interfaces/GalleryInterfaces';
-import { tableView, wordTrim } from './viewutils';
+import { ratingStars, tableView, wordTrim } from './viewutils';
+import { ExtensionStatiticsMap } from './show';
 const installationTarget = 'Microsoft.VisualStudio.Code';
 const excludeFlags = '37888'; //Value to exclude un-published, locked or hidden extensions
 
 interface VSCodePublishedExtension extends PublishedExtension {
 	publisher: { displayName: string; publisherName: string };
 }
-
-export async function search(searchText: string, json: boolean = false, pageSize: number = 10): Promise<any> {
+export async function search(
+	searchText: string,
+	json: boolean = false,
+	pageSize: number = 10,
+	stats: boolean = false
+): Promise<any> {
 	const api = getPublicGalleryAPI();
 	const results = (await api.extensionQuery({
 		pageSize,
@@ -21,8 +27,34 @@ export async function search(searchText: string, json: boolean = false, pageSize
 			{ filterType: ExtensionQueryFilterType.InstallationTarget, value: installationTarget },
 			{ filterType: ExtensionQueryFilterType.ExcludeWithFlags, value: excludeFlags },
 		],
-		flags: [ExtensionQueryFlags.ExcludeNonValidated, ExtensionQueryFlags.IncludeLatestVersionOnly],
+		flags: [
+			ExtensionQueryFlags.ExcludeNonValidated,
+			ExtensionQueryFlags.IncludeLatestVersionOnly,
+			ExtensionQueryFlags.IncludeStatistics,
+		],
 	})) as VSCodePublishedExtension[];
+
+	if (stats) {
+		console.log(
+			[
+				`Search results:`,
+				'',
+				...tableView([
+					['<ExtensionId>', '<Name>', '<Installs>', '<Rating>'],
+					...results.map(({ publisher: { publisherName }, extensionName, displayName, statistics }) => [
+						publisherName + '.' + extensionName,
+						wordTrim(displayName || '', 25),
+						getStats(statistics!),
+					]),
+				]),
+				'',
+				'For more information on an extension use "vsce show <extensionId>"',
+			]
+				.map(line => wordTrim(line.replace(/\s+$/g, '')))
+				.join('\n')
+		);
+		return;
+	}
 
 	if (json) {
 		console.log(JSON.stringify(results, undefined, '\t'));
@@ -42,8 +74,8 @@ export async function search(searchText: string, json: boolean = false, pageSize
 				['<ExtensionId>', '<Name>', '<Description>'],
 				...results.map(({ publisher: { publisherName }, extensionName, displayName, shortDescription }) => [
 					publisherName + '.' + extensionName,
-					displayName || '',
-					(shortDescription || '').replace(/\n|\r|\t/g, ' '),
+					wordTrim(displayName || '', 25),
+					wordTrim(shortDescription || '', 150).replace(/\n|\r|\t/g, ' '),
 				]),
 			]),
 			'',
@@ -51,5 +83,16 @@ export async function search(searchText: string, json: boolean = false, pageSize
 		]
 			.map(line => wordTrim(line.replace(/\s+$/g, '')))
 			.join('\n')
+	);
+}
+function getStats(statistics: ExtensionStatistic[]): string {
+	const { install: installs = 0, averagerating = 0, ratingcount = 0 } = statistics?.reduce(
+		(map, { statisticName, value }) => ({ ...map, [statisticName!]: value }),
+		<ExtensionStatiticsMap>{}
+	);
+
+	return (
+		`${Number(installs).toLocaleString('en-US').padStart(12, ' ')} \t\t` +
+		` ${ratingStars(averagerating).padEnd(3, ' ')} (${ratingcount})`
 	);
 }


### PR DESCRIPTION
PR to fix issue #727 

New search command usage

```
Usage: vsce search [options] <text>

search extension gallery

Options:
  --json                  Output result in json format (default: false)
  --stats                 Shows the extension rating and download counts (default: false)
  -p, --pagesize [value]  Number of results to return (default: "100")
  -h, --help              display help for comman
```

Result:

<img width="1109" alt="image" src="https://user-images.githubusercontent.com/328076/168586733-8b5fa0e5-f24a-4022-9cdf-95ce4ef3ed7a.png">
