### PR TITLE
fix: ensure that we can define dependency argument in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Or you can also set them in the `package.json`, so that you avoid having to rety
 {
   "vsce": {
     "baseImagesUrl": "https://my.custom/base/images/url"
+    "dependencies": true,
+    "yarn": false
   }
 }
 ```

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,9 @@ module.exports = function (argv: string[]): void {
 			undefined
 		)
 		.option('--ignoreFile <path>', 'Indicate alternative .vscodeignore')
-		.option('--no-dependencies', 'Disable dependency detection via npm or yarn')
+		// default must remain undefined for dependencies or we will fail to load defaults from package.json
+		.option('--dependencies', 'Enable dependency detection via npm or yarn', undefined)
+		.option('--no-dependencies', 'Disable dependency detection via npm or yarn', undefined)
 		.action(({ yarn, packagedDependencies, ignoreFile, dependencies }) =>
 			main(ls({ useYarn: yarn, packagedDependencies, ignoreFile, dependencies }))
 		);
@@ -102,6 +104,8 @@ module.exports = function (argv: string[]): void {
 		.option('--ignoreFile <path>', 'Indicate alternative .vscodeignore')
 		.option('--no-gitHubIssueLinking', 'Disable automatic expansion of GitHub-style issue syntax into links')
 		.option('--no-gitLabIssueLinking', 'Disable automatic expansion of GitLab-style issue syntax into links')
+		// default must remain undefined for dependencies or we will fail to load defaults from package.json
+		.option('--dependencies', 'Enable dependency detection via npm or yarn', undefined)
 		.option('--no-dependencies', 'Disable dependency detection via npm or yarn')
 		.option('--pre-release', 'Mark this package as a pre-release')
 		.option('--allow-star-activation', 'Allow using * in activation events')
@@ -185,7 +189,9 @@ module.exports = function (argv: string[]): void {
 		.option('--no-yarn', 'Use npm instead of yarn (default inferred from lack of yarn.lock or .yarnrc)')
 		.option('--noVerify')
 		.option('--ignoreFile <path>', 'Indicate alternative .vscodeignore')
-		.option('--no-dependencies', 'Disable dependency detection via npm or yarn')
+		// default must remain undefined for dependencies or we will fail to load defaults from package.json
+		.option('--dependencies', 'Enable dependency detection via npm or yarn', undefined)
+		.option('--no-dependencies', 'Disable dependency detection via npm or yarn', undefined)
 		.option('--pre-release', 'Mark this package as a pre-release')
 		.option('--allow-star-activation', 'Allow using * in activation events')
 		.option('--allow-missing-repository', 'Allow missing a repository URL in package.json')


### PR DESCRIPTION
Commander documentation states that when using negative commands, if you do not already have a non-negative command it sets the default to `true`, which is what broke the logic for loading defaults from `package.json`.

Fixes: #742
Reference: https://www.npmjs.com/package/commander#other-option-types-negatable-boolean-and-booleanvalue