### PR TITLE
feat: support pricing model in the manifest file

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -79,6 +79,7 @@ export interface Manifest {
 	dependencies?: { [name: string]: string };
 	devDependencies?: { [name: string]: string };
 	private?: boolean;
+	pricing?: string;
 
 	// vsce
 	vsce?: any;

--- a/src/package.ts
+++ b/src/package.ts
@@ -129,6 +129,7 @@ export interface VSIX {
 	localizedLanguages: string;
 	preRelease: boolean;
 	sponsorLink: string;
+	pricing: string;
 }
 
 export class BaseProcessor implements IProcessor {
@@ -432,6 +433,7 @@ export class ManifestProcessor extends BaseProcessor {
 			target,
 			engine: manifest.engines['vscode'],
 			description: manifest.description ?? '',
+			pricing: manifest.pricing ?? 'Free',
 			categories: (manifest.categories ?? []).join(','),
 			flags: flags.join(' '),
 			links: {
@@ -1148,6 +1150,10 @@ export function validateManifest(manifest: Manifest): Manifest {
 		throw new Error('Manifest missing field: version');
 	}
 
+	if (manifest.pricing && !['Free', 'Trial'].includes(manifest.pricing)) {
+		throw new Error('Pricing should be Free or Trial');
+	}
+
 	validateVersion(manifest.version);
 
 	if (!manifest.engines) {
@@ -1361,6 +1367,8 @@ export async function toVsixManifest(vsix: VSIX): Promise<string> {
 						: ''
 				}
 				<Property Id="Microsoft.VisualStudio.Services.GitHubFlavoredMarkdown" Value="${escape(vsix.githubMarkdown)}" />
+				<Property Id="Microsoft.VisualStudio.Services.Content.Pricing" Value="${escape(vsix.pricing)}"/>
+
 				${
 					vsix.enableMarketplaceQnA !== undefined
 						? `<Property Id="Microsoft.VisualStudio.Services.EnableMarketplaceQnA" Value="${escape(

--- a/src/package.ts
+++ b/src/package.ts
@@ -1150,7 +1150,7 @@ export function validateManifest(manifest: Manifest): Manifest {
 		throw new Error('Manifest missing field: version');
 	}
 
-	if (manifest.pricing && !['Free', 'Trial'].includes(manifest.pricing)) {
+	if (manifest.pricing && !['free', 'trial'].includes(manifest.pricing.toLowerCase())) {
 		throw new Error('Pricing should be Free or Trial');
 	}
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -1150,7 +1150,7 @@ export function validateManifest(manifest: Manifest): Manifest {
 		throw new Error('Manifest missing field: version');
 	}
 
-	if (manifest.pricing && !['free', 'trial'].includes(manifest.pricing.toLowerCase())) {
+	if (manifest.pricing && !['Free', 'Trial'].includes(manifest.pricing)) {
 		throw new Error('Pricing should be Free or Trial');
 	}
 

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -390,6 +390,13 @@ describe('validateManifest', () => {
 		validateManifest(createManifest({ sponsor: { url: 'https://foo.bar' } }));
 		validateManifest(createManifest({ sponsor: { url: 'http://www.foo.com' } }));
 	});
+
+	it('should validate pricing', () => {
+		assert.throws(() => validateManifest(createManifest({ pricing: 'Paid' })));
+		validateManifest(createManifest({ pricing: 'Trial' }));
+		validateManifest(createManifest({ pricing: 'Free' }));
+		validateManifest(createManifest());
+	});
 });
 
 describe('toVsixManifest', () => {
@@ -1723,6 +1730,13 @@ describe('toVsixManifest', () => {
 		}
 
 		throw new Error('Should not reach here');
+	});
+
+	it('should identify trial version of an extension', async () => {
+		const manifest = createManifest({ pricing: 'Trial' });
+		var raw = await _toVsixManifest(manifest, []);
+		const xmlManifest = await parseXmlManifest(raw);
+		assertProperty(xmlManifest, 'Microsoft.VisualStudio.Services.Content.Pricing', 'Trial');
 	});
 });
 


### PR DESCRIPTION
Added the support for extension authors label an extension as `FREE` or `FREE TRIAL`

#748