### PR TITLE
fix: support fragments in image URLs

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -709,7 +709,7 @@ export class MarkdownProcessor extends BaseProcessor {
 			contents = contents.replace(markdownPathRegex, urlReplace);
 
 			// Replace <img> links with urls
-			contents = contents.replace(/<img.+?src=["']([/.\w\s-]+)['"].*?>/g, (all, link) => {
+			contents = contents.replace(/<img.+?src=["']([/.\w\s#-]+)['"].*?>/g, (all, link) => {
 				const isLinkRelative = !/^\w+:\/\//.test(link) && link[0] !== '#';
 
 				if (!this.baseImagesUrl && isLinkRelative) {

--- a/src/test/fixtures/readme/readme.branch.main.expected.md
+++ b/src/test/fixtures/readme/readme.branch.main.expected.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](https://github.com/username/repository/raw/main/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/main/monkey)
 ![](https://github.com/username/repository/raw/main/images/SpellMDDemo2.gif)
 ![](https://github.com/username/repository/raw/main/SpellMDDemo2.gif)
+![](https://github.com/username/repository/raw/main/SpellMDDemo2.gif#gh-light-mode-only)
 <img src="https://github.com/username/repository/raw/main/images/myImage.gif">
+<img src="https://github.com/username/repository/raw/main/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.branch.override.content.expected.md
+++ b/src/test/fixtures/readme/readme.branch.override.content.expected.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](https://github.com/base/images/SpellMDDemo2.gif)](https://github.com/base/monkey)
 ![](https://github.com/base/images/SpellMDDemo2.gif)
 ![](https://github.com/base/SpellMDDemo2.gif)
+![](https://github.com/base/SpellMDDemo2.gif#gh-light-mode-only)
 <img src="https://github.com/base/images/myImage.gif">
+<img src="https://github.com/base/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.branch.override.images.expected.md
+++ b/src/test/fixtures/readme/readme.branch.override.images.expected.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](https://github.com/base/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/main/monkey)
 ![](https://github.com/base/images/SpellMDDemo2.gif)
 ![](https://github.com/base/SpellMDDemo2.gif)
+![](https://github.com/base/SpellMDDemo2.gif#gh-light-mode-only)
 <img src="https://github.com/base/images/myImage.gif">
+<img src="https://github.com/base/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.default.md
+++ b/src/test/fixtures/readme/readme.default.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](https://github.com/username/repository/raw/HEAD/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/HEAD/monkey)
 ![](https://github.com/username/repository/raw/HEAD/images/SpellMDDemo2.gif)
 ![](https://github.com/username/repository/raw/HEAD/SpellMDDemo2.gif)
+![](https://github.com/username/repository/raw/HEAD/SpellMDDemo2.gif#gh-light-mode-only)
 <img src="https://github.com/username/repository/raw/HEAD/images/myImage.gif">
+<img src="https://github.com/username/repository/raw/HEAD/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.expected.md
+++ b/src/test/fixtures/readme/readme.expected.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](https://github.com/username/repository/raw/master/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/master/monkey)
 ![](https://github.com/username/repository/raw/master/images/SpellMDDemo2.gif)
 ![](https://github.com/username/repository/raw/master/SpellMDDemo2.gif)
+![](https://github.com/username/repository/raw/master/SpellMDDemo2.gif#gh-light-mode-only)
 <img src="https://github.com/username/repository/raw/master/images/myImage.gif">
+<img src="https://github.com/username/repository/raw/master/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.gitlab.branch.main.expected.md
+++ b/src/test/fixtures/readme/readme.gitlab.branch.main.expected.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](https://gitlab.com/username/repository/-/raw/main/images/SpellMDDemo2.gif)](https://gitlab.com/username/repository/-/blob/main/monkey)
 ![](https://gitlab.com/username/repository/-/raw/main/images/SpellMDDemo2.gif)
 ![](https://gitlab.com/username/repository/-/raw/main/SpellMDDemo2.gif)
+![](https://gitlab.com/username/repository/-/raw/main/SpellMDDemo2.gif#gh-light-mode-only)
 <img src="https://gitlab.com/username/repository/-/raw/main/images/myImage.gif">
+<img src="https://gitlab.com/username/repository/-/raw/main/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.gitlab.branch.override.content.expected.md
+++ b/src/test/fixtures/readme/readme.gitlab.branch.override.content.expected.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](https://gitlab.com/base/images/SpellMDDemo2.gif)](https://gitlab.com/base/monkey)
 ![](https://gitlab.com/base/images/SpellMDDemo2.gif)
 ![](https://gitlab.com/base/SpellMDDemo2.gif)
+![](https://gitlab.com/base/SpellMDDemo2.gif#gh-light-mode-only)
 <img src="https://gitlab.com/base/images/myImage.gif">
+<img src="https://gitlab.com/base/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.gitlab.branch.override.images.expected.md
+++ b/src/test/fixtures/readme/readme.gitlab.branch.override.images.expected.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](https://gitlab.com/base/images/SpellMDDemo2.gif)](https://gitlab.com/username/repository/-/blob/main/monkey)
 ![](https://gitlab.com/base/images/SpellMDDemo2.gif)
 ![](https://gitlab.com/base/SpellMDDemo2.gif)
+![](https://gitlab.com/base/SpellMDDemo2.gif#gh-light-mode-only)
 <img src="https://gitlab.com/base/images/myImage.gif">
+<img src="https://gitlab.com/base/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.gitlab.default.md
+++ b/src/test/fixtures/readme/readme.gitlab.default.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](https://gitlab.com/username/repository/-/raw/HEAD/images/SpellMDDemo2.gif)](https://gitlab.com/username/repository/-/blob/HEAD/monkey)
 ![](https://gitlab.com/username/repository/-/raw/HEAD/images/SpellMDDemo2.gif)
 ![](https://gitlab.com/username/repository/-/raw/HEAD/SpellMDDemo2.gif)
+![](https://gitlab.com/username/repository/-/raw/HEAD/SpellMDDemo2.gif#gh-light-mode-only)
 <img src="https://gitlab.com/username/repository/-/raw/HEAD/images/myImage.gif">
+<img src="https://gitlab.com/username/repository/-/raw/HEAD/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.images.expected.md
+++ b/src/test/fixtures/readme/readme.images.expected.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](https://github.com/username/repository/path/to/images/SpellMDDemo2.gif)](https://github.com/username/repository/blob/HEAD/monkey)
 ![](https://github.com/username/repository/path/to/images/SpellMDDemo2.gif)
 ![](https://github.com/username/repository/path/to/SpellMDDemo2.gif)
+![](https://github.com/username/repository/path/to/SpellMDDemo2.gif#gh-light-mode-only)
 <img src="https://github.com/username/repository/path/to/images/myImage.gif">
+<img src="https://github.com/username/repository/path/to/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 

--- a/src/test/fixtures/readme/readme.md
+++ b/src/test/fixtures/readme/readme.md
@@ -22,7 +22,9 @@ The status bar lets you quickly navigate to any issue and you can see all positi
 [![Jump to issues](images/SpellMDDemo2.gif)](monkey)
 ![](images/SpellMDDemo2.gif)
 ![](./SpellMDDemo2.gif)
+![](./SpellMDDemo2.gif#gh-light-mode-only)
 <img src="/images/myImage.gif">
+<img src="/images/myImage.gif#gh-light-mode-only">
 
 The `spellMD.json` config file is watched so you can add more ignores or change mappings at will.
 


### PR DESCRIPTION
This PR fixes #739 by taking the `#` character into account in image URLs.

### Description

When inserting images in a markdown file using the HTML tag, relative image URLs that contain a `#` character do not get prefixed with the base URL.

```html
<img src="/images/myImage.gif#gh-light-mode-only">
```

Later when validating image URLs, a relative URL is passed to the `URL` constructor, which results in an error being thrown.

https://github.com/microsoft/vscode-vsce/blob/955c76056f8f173e8cef180936b8c11c42af6be9/src/package.ts#L779-L782

### Fixes

The regex responsible for replacing <img> links has been modified to support the `#` character.

I have also updated the test suite accordingly.