### PR TITLE
feat: expose all options to packaging and publishing APIs

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,8 @@
 import { publish as _publish, IPublishOptions as _IPublishOptions } from './publish';
 import { packageCommand, listFiles as _listFiles, IPackageOptions } from './package';
 
+export { IPackageOptions };
+
 /**
  * @deprecated prefer IPackageOptions instead
  */

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { publish as _publish } from './publish';
+import { publish as _publish, IPublishOptions as _IPublishOptions } from './publish';
 import { packageCommand, listFiles as _listFiles, IPackageOptions } from './package';
 
 /**
@@ -49,14 +49,9 @@ export interface IListFilesOptions {
 	ignoreFile?: string;
 }
 
-export interface IPublishVSIXOptions extends IBaseVSIXOptions {
-	/**
-	 * The Personal Access Token to use.
-	 *
-	 * Defaults to the stored one.
-	 */
-	pat?: string;
-}
+export type IPublishVSIXOptions = IPublishOptions & Pick<IPackageOptions, 'target'>;
+
+export type IPublishOptions = _IPublishOptions;
 
 /**
  * Creates a VSIX from the extension in the current working directory.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 import { publish as _publish, IPublishOptions as _IPublishOptions } from './publish';
 import { packageCommand, listFiles as _listFiles, IPackageOptions } from './package';
 
-export { IPackageOptions };
+export type { IPackageOptions } from './package';
 
 /**
  * @deprecated prefer IPackageOptions instead

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,7 +6,7 @@ import { packageCommand, listFiles as _listFiles, IPackageOptions } from './pack
  */
 export type IBaseVSIXOptions = Pick<
 	IPackageOptions,
-	'baseContentUrl' | 'baseImagesUrl' | 'githubBranch' | 'gitlabBranch' | 'useYarn' | 'target' | 'preRelease' | 'version'
+	'baseContentUrl' | 'baseImagesUrl' | 'githubBranch' | 'gitlabBranch' | 'useYarn' | 'target' | 'preRelease'
 >;
 
 /**

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,93 +1,18 @@
 import { publish as _publish } from './publish';
-import { packageCommand, listFiles as _listFiles } from './package';
+import { packageCommand, listFiles as _listFiles, IPackageOptions } from './package';
 
-export interface IBaseVSIXOptions {
-	/**
-	 * The base URL for links detected in Markdown files.
-	 */
-	baseContentUrl?: string;
+/**
+ * @deprecated prefer IPackageOptions instead
+ */
+export type IBaseVSIXOptions = Pick<
+	IPackageOptions,
+	'baseContentUrl' | 'baseImagesUrl' | 'githubBranch' | 'gitlabBranch' | 'useYarn' | 'target' | 'preRelease' | 'version'
+>;
 
-	/**
-	 * The base URL for images detected in Markdown files.
-	 */
-	baseImagesUrl?: string;
-
-	/**
-	 * Github branch used to publish the package. Used to automatically infer
-	 * the base content and images URI.
-	 */
-	githubBranch?: string;
-
-	/**
-	 * Gitlab branch used to publish the package. Used to automatically infer
-	 * the base content and images URI.
-	 */
-	gitlabBranch?: string;
-
-	/**
-	 * Should use Yarn instead of NPM.
-	 */
-	useYarn?: boolean;
-
-	/**
-	 * Optional target the extension should run on.
-	 *
-	 * https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions
-	 */
-	target?: string;
-
-	/**
-	 * Mark this package as a pre-release
-	 */
-	preRelease?: boolean;
-}
-
-export interface ICreateVSIXOptions extends IBaseVSIXOptions {
-	/**
-	 * The location of the extension in the file system.
-	 *
-	 * Defaults to `process.cwd()`.
-	 */
-	cwd?: string;
-
-	/**
-	 * The destination of the packaged the VSIX.
-	 *
-	 * Defaults to `NAME-VERSION.vsix`.
-	 */
-	packagePath?: string;
-}
-
-export interface IPublishOptions {
-	/**
-	 * The location of the extension in the file system.
-	 *
-	 * Defaults to `process.cwd()`.
-	 */
-	cwd?: string;
-
-	/**
-	 * The Personal Access Token to use.
-	 *
-	 * Defaults to the stored one.
-	 */
-	pat?: string;
-
-	/**
-	 * The base URL for links detected in Markdown files.
-	 */
-	baseContentUrl?: string;
-
-	/**
-	 * The base URL for images detected in Markdown files.
-	 */
-	baseImagesUrl?: string;
-
-	/**
-	 * Should use Yarn instead of NPM.
-	 */
-	useYarn?: boolean;
-}
+/**
+ * @deprecated prefer IPackageOptions instead
+ */
+export type ICreateVSIXOptions = Pick<IPackageOptions, 'cwd' | 'packagePath'> & IBaseVSIXOptions;
 
 /**
  * The supported list of package managers.
@@ -136,7 +61,7 @@ export interface IPublishVSIXOptions extends IBaseVSIXOptions {
 /**
  * Creates a VSIX from the extension in the current working directory.
  */
-export function createVSIX(options: ICreateVSIXOptions = {}): Promise<any> {
+export function createVSIX(options: IPackageOptions = {}): Promise<any> {
 	return packageCommand(options);
 }
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -67,24 +67,67 @@ export interface IAsset {
 }
 
 export interface IPackageOptions {
+	/**
+	 * The destination of the packaged the VSIX.
+	 *
+	 * Defaults to `NAME-VERSION.vsix`.
+	 */
 	readonly packagePath?: string;
 	readonly version?: string;
+
+	/**
+	 * Optional target the extension should run on.
+	 *
+	 * https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions
+	 */
 	readonly target?: string;
 	readonly commitMessage?: string;
 	readonly gitTagVersion?: boolean;
 	readonly updatePackageJson?: boolean;
+
+	/**
+	 * The location of the extension in the file system.
+	 *
+	 * Defaults to `process.cwd()`.
+	 */
 	readonly cwd?: string;
+
+	/**
+	 * Github branch used to publish the package. Used to automatically infer
+	 * the base content and images URI.
+	 */
 	readonly githubBranch?: string;
+
+	/**
+	 * Gitlab branch used to publish the package. Used to automatically infer
+	 * the base content and images URI.
+	 */
 	readonly gitlabBranch?: string;
+
 	readonly rewriteRelativeLinks?: boolean;
+	/**
+	 * The base URL for links detected in Markdown files.
+	 */
 	readonly baseContentUrl?: string;
+
+	/**
+	 * The base URL for images detected in Markdown files.
+	 */
 	readonly baseImagesUrl?: string;
+
+	/**
+	 * Should use Yarn instead of NPM.
+	 */
 	readonly useYarn?: boolean;
 	readonly dependencyEntryPoints?: string[];
 	readonly ignoreFile?: string;
 	readonly gitHubIssueLinking?: boolean;
 	readonly gitLabIssueLinking?: boolean;
 	readonly dependencies?: boolean;
+
+	/**
+	 * Mark this package as a pre-release
+	 */
 	readonly preRelease?: boolean;
 	readonly allowStarActivation?: boolean;
 	readonly allowMissingRepository?: boolean;

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -19,14 +19,38 @@ export interface IPublishOptions {
 	readonly commitMessage?: string;
 	readonly gitTagVersion?: boolean;
 	readonly updatePackageJson?: boolean;
+
+	/**
+	 * The location of the extension in the file system.
+	 *
+	 * Defaults to `process.cwd()`.
+	 */
 	readonly cwd?: string;
 	readonly githubBranch?: string;
 	readonly gitlabBranch?: string;
+
+	/**
+	 * The base URL for links detected in Markdown files.
+	 */
 	readonly baseContentUrl?: string;
+
+	/**
+	 * The base URL for images detected in Markdown files.
+	 */
 	readonly baseImagesUrl?: string;
+
+	/**
+	 * Should use Yarn instead of NPM.
+	 */
 	readonly useYarn?: boolean;
 	readonly dependencyEntryPoints?: string[];
 	readonly ignoreFile?: string;
+
+	/**
+	 * The Personal Access Token to use.
+	 *
+	 * Defaults to the stored one.
+	 */
 	readonly pat?: string;
 	readonly noVerify?: boolean;
 	readonly dependencies?: boolean;


### PR DESCRIPTION
This PR introduces modifications to allow the API methods to use all options currently supported by the CLI.

The following modifications have been made:

### Packaging

1. The `createVSIX` function now accepts an `IPackageOptions` instead of `ICreateVSIXOptions`
2. The existing `ICreateVSIXOptions` has been kept in the file and refactored to stay backward compatible.
3. The `ICreateVSIXOptions` has been marked as deprecated to encourage using `IPackageOptions` instead.

### Publishing

1. The `publishVSIX` function still accepts an `IPublishOptions` but it's currently an alias to the `IPublishOptions` type declared in `publish.ts`
2. The `IPublishVSIXOptions` has been refactored to extend from `IPublishOptions` and also includes the needed `target` property.

This should in _theory_ be backward compatible because all existing types can still be imported and they were subsets of the types declared for the CLI.

### Todo

- [x] Move documentation comments to their respective interfaces

---

Closes #754 