### PR TITLE
fix: correct program path in `launch.json`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 			"request": "launch",
 			"name": "Launch Program",
 			// "cwd": "<absolute path to your extension>",
-			"program": "${workspaceFolder}/out/vsce",
+			"program": "${workspaceFolder}/vsce",
 			"args": [
 				"--version"
 				// "ls", "package", "publish"


### PR DESCRIPTION
Current `program` path does not exist (anymore, I guess).