### PR TITLE
feat: prompt for full name to confirm unpublish action (#782)

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -242,9 +242,9 @@ export async function unpublish(options: IUnpublishOptions = {}): Promise<any> {
 	const fullName = `${publisher}.${name}`;
 
 	if (!options.force) {
-		const answer = await read(`This will FOREVER delete '${fullName}'! Are you sure? [y/N] `);
+		const answer = await read(`This will delete ALL published versions! Please type '${fullName}' to confirm: `);
 
-		if (!/^y$/i.test(answer)) {
+		if (answer !== fullName) {
 			throw new Error('Aborted');
 		}
 	}


### PR DESCRIPTION
I did some testing on local by using a dummy `package.json` and this appears to work.

Test environments:

Windows 11 | Git Bash | Running `./vsce` directly -> no interactive prompt, does not unpublish
Windows 11 | Git Bash | Running with `winpty ./vsce` -> interactive prompts, works as expected
Windows 11 | Powershell | Running with `node vsce` -> interactive prompts, works as expected

Did not test WSL/Linux or Mac, but I can't imagine the behavior is different.