### PR TITLE
(#868) publish option --skip-duplicate doesn't consider target platforms

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -173,17 +173,18 @@ async function _publish(packagePath: string, manifest: Manifest, options: IInter
 		}
 
 		if (extension && extension.versions) {
-			const sameVersion = extension.versions.filter(v => v.version === manifest.version);
+			const versionExists = extension.versions.some(v =>
+				(v.version === manifest.version) &&
+				(options.target ? v.targetPlatform === options.target : true));
 
-			if (sameVersion.length > 0) {
+			if (versionExists) {
 				if (options.skipDuplicate) {
 					log.done(`Version ${manifest.version} is already published. Skipping publish.`);
 					return;
-				}
-
-				if (sameVersion.some(v => v.targetPlatform === options.target)) {
+				} else {
 					throw new Error(`${description} already exists.`);
 				}
+
 			}
 
 			try {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-vsce/issues/868

### Problem:
When publishing multiple `vsix` packages with different target platforms using the `--packagePath` flag and the `--skip-duplicate` flag, only the first package is published. After that, all the others are considered duplicate versions and are not published.

### Solution:
Always consider the target platform along with the version when the `target` is present in the publish options

I did not see any relevant test cases for this code, so please let me know if I missed it and I will update the PR.

Thanks!

FYI @mbehr1