### PR TITLE
Add support for misspelled license name

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -930,8 +930,8 @@ class LicenseProcessor extends BaseProcessor {
 		const match = /^SEE LICENSE IN (.*)$/.exec(manifest.license || '');
 
 		if (!match || !match[1]) {
-			this.expectedLicenseName = 'LICENSE.md, LICENSE.txt or LICENSE';
-			this.filter = name => /^extension\/license(\.(md|txt))?$/i.test(name);
+			this.expectedLicenseName = 'LICENSE, LICENSE.md, or LICENSE.txt';
+			this.filter = name => /^extension\/licen[cs]e(\.(md|txt))?$/i.test(name);
 		} else {
 			this.expectedLicenseName = match[1];
 			const regexp = new RegExp('^extension/' + match[1] + '$');

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -689,6 +689,32 @@ describe('toVsixManifest', () => {
 			});
 	});
 
+	it('should automatically detect misspelled license files', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+		};
+
+		const files = [{ path: 'extension/LICENCE.md', contents: '' }];
+
+		return _toVsixManifest(manifest, files)
+			.then(xml => parseXmlManifest(xml))
+			.then(result => {
+				assert.ok(result.PackageManifest.Metadata[0].License);
+				assert.strictEqual(result.PackageManifest.Metadata[0].License.length, 1);
+				assert.strictEqual(result.PackageManifest.Metadata[0].License[0], 'extension/LICENCE.md');
+				assert.strictEqual(result.PackageManifest.Assets[0].Asset.length, 2);
+				assert.strictEqual(
+					result.PackageManifest.Assets[0].Asset[1].$.Type,
+					'Microsoft.VisualStudio.Services.Content.License'
+				);
+				assert.strictEqual(result.PackageManifest.Assets[0].Asset[1].$.Path, 'extension/LICENCE.md');
+			});
+	});
+
 	it('should add an icon metadata tag', () => {
 		const manifest = {
 			name: 'test',


### PR DESCRIPTION
* Supported naming:
  * correct: LICENSE, license
  * commonly misspelled: LICENCE, licence
* Supported formats: no extension, .md, .txt

<s>To Do: tests</s>

Closes #870 
