### PR TITLE
feat: add user-friendly info to --help

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"azure-devops-node-api": "^11.0.1",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
-				"commander": "^6.1.0",
+				"commander": "^6.2.1",
 				"glob": "^7.0.6",
 				"hosted-git-info": "^4.0.2",
 				"jsonc-parser": "^3.2.0",
@@ -802,9 +802,9 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "6.1.0",
-			"resolved": "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz",
-			"integrity": "sha1-+Ncit4EDFBAGtm9Me6HpcxW6dbw= sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
 			"engines": {
 				"node": ">= 6"
 			}
@@ -3529,9 +3529,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "6.1.0",
-			"resolved": "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz",
-			"integrity": "sha1-+Ncit4EDFBAGtm9Me6HpcxW6dbw= sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA=="
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
 		},
 		"concat-map": {
 			"version": "0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -802,9 +802,9 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "6.1.0",
-			"resolved": "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz",
-			"integrity": "sha1-+Ncit4EDFBAGtm9Me6HpcxW6dbw= sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
 			"engines": {
 				"node": ">= 6"
 			}
@@ -3529,9 +3529,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "6.1.0",
-			"resolved": "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz",
-			"integrity": "sha1-+Ncit4EDFBAGtm9Me6HpcxW6dbw= sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA=="
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
 		},
 		"concat-map": {
 			"version": "0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@vscode/vsce",
-			"version": "2.20.0",
+			"version": "2.20.1",
 			"license": "MIT",
 			"dependencies": {
 				"azure-devops-node-api": "^11.0.1",
@@ -802,9 +802,9 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz",
+			"integrity": "sha1-+Ncit4EDFBAGtm9Me6HpcxW6dbw= sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
 			"engines": {
 				"node": ">= 6"
 			}
@@ -3529,9 +3529,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+			"version": "6.1.0",
+			"resolved": "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz",
+			"integrity": "sha1-+Ncit4EDFBAGtm9Me6HpcxW6dbw= sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA=="
 		},
 		"concat-map": {
 			"version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@vscode/vsce",
 	"version": "2.20.0",
-	"description": "VSCode Extension Manager",
+	"description": "VS Code Extensions Manager",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Microsoft/vsce"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"azure-devops-node-api": "^11.0.1",
 		"chalk": "^2.4.2",
 		"cheerio": "^1.0.0-rc.9",
-		"commander": "^6.1.0",
+		"commander": "^6.2.1",
 		"glob": "^7.0.6",
 		"hosted-git-info": "^4.0.2",
 		"jsonc-parser": "^3.2.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,37 +298,30 @@ module.exports = function (argv: string[]): void {
 		.description('search extension gallery')
 		.action((text, { json, pagesize, stats }) => main(search(text, json, parseInt(pagesize), stats)));
 
-		program.on('command:*', ([cmd]: string) => {
-			if (cmd === 'create-publisher') {
-				log.error(
-					`The 'create-publisher' command is no longer available. You can create a publisher directly in the Marketplace: https://aka.ms/vscode-create-publisher`
-					);
-					
-					process.exit(1);
-				}
-				
-				program.outputHelp(help => {
-					const availableCommands = program.commands.map(c => c._name);
-					const suggestion = availableCommands.find(c => leven(c, cmd) < c.length * 0.4);
+	program.on('command:*', ([cmd]: string) => {
+		if (cmd === 'create-publisher') {
+			log.error(
+				`The 'create-publisher' command is no longer available. You can create a publisher directly in the Marketplace: https://aka.ms/vscode-create-publisher`
+			);
 
-					help = `${help}
+			process.exit(1);
+		}
+
+		program.outputHelp(help => {
+			const availableCommands = program.commands.map(c => c._name);
+			const suggestion = availableCommands.find(c => leven(c, cmd) < c.length * 0.4);
+
+			help = `${help}
 Unknown command '${cmd}'`;
-					
-					return suggestion ? `${help}, did you mean '${suggestion}'?\n` : `${help}.\n`;
-				});
-				process.exit(1);
-			});
-			
-	program.description(`
-  ==    ==  .====.   .=====.  .=====.
-  ||    || ||       ||       ||
-  ||    ||  '====.  ||       ||===
-   \\\\  //        || ||       ||
-    '=='    '===='   '====='  '====='\n
-${pkg.description}\n
+
+			return suggestion ? `${help}, did you mean '${suggestion}'?\n` : `${help}.\n`;
+		});
+		process.exit(1);
+	});
+
+	program.description(`${pkg.description}\n
 - To learn more about the VS Code extension API, please visit https://code.visualstudio.com/api/extension-guides/overview
-- To connect with the VS Code extension developer community, please visit https://github.com/microsoft/vscode-discussions
-\n==========================`);
-  
+- To connect with the VS Code extension developer community, please visit https://github.com/microsoft/vscode-discussions`);
+
 	program.parse(argv);
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -319,9 +319,9 @@ Unknown command '${cmd}'`;
 		process.exit(1);
 	});
 
-	program.description(`${pkg.description}\n
-- To learn more about the VS Code extension API, please visit https://code.visualstudio.com/api/extension-guides/overview
-- To connect with the VS Code extension developer community, please visit https://github.com/microsoft/vscode-discussions`);
+	program.description(`${pkg.description}
+To learn more about the VS Code extension API: https://aka.ms/vscode-extension-api
+To connect with the VS Code extension developer community: https://aka.ms/vscode-discussions`);
 
 	program.parse(argv);
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,26 +298,37 @@ module.exports = function (argv: string[]): void {
 		.description('search extension gallery')
 		.action((text, { json, pagesize, stats }) => main(search(text, json, parseInt(pagesize), stats)));
 
-	program.on('command:*', ([cmd]: string) => {
-		if (cmd === 'create-publisher') {
-			log.error(
-				`The 'create-publisher' command is no longer available. You can create a publisher directly in the Marketplace: https://aka.ms/vscode-create-publisher`
-			);
+		program.on('command:*', ([cmd]: string) => {
+			if (cmd === 'create-publisher') {
+				log.error(
+					`The 'create-publisher' command is no longer available. You can create a publisher directly in the Marketplace: https://aka.ms/vscode-create-publisher`
+					);
+					
+					process.exit(1);
+				}
+				
+				program.outputHelp(help => {
+					const availableCommands = program.commands.map(c => c._name);
+					const suggestion = availableCommands.find(c => leven(c, cmd) < c.length * 0.4);
 
-			process.exit(1);
-		}
-
-		program.outputHelp(help => {
-			const availableCommands = program.commands.map(c => c._name);
-			const suggestion = availableCommands.find(c => leven(c, cmd) < c.length * 0.4);
-
-			help = `${help}
+					help = `${help}
 Unknown command '${cmd}'`;
-
-			return suggestion ? `${help}, did you mean '${suggestion}'?\n` : `${help}.\n`;
-		});
-		process.exit(1);
-	});
-
+					
+					return suggestion ? `${help}, did you mean '${suggestion}'?\n` : `${help}.\n`;
+				});
+				process.exit(1);
+			});
+			
+	program.description(`
+  ==    ==  .====.   .=====.  .=====.
+  ||    || ||       ||       ||
+  ||    ||  '====.  ||       ||===
+   \\\\  //        || ||       ||
+    '=='    '===='   '====='  '====='\n
+${pkg.description}\n
+- To learn more about the VS Code extension API, please visit https://code.visualstudio.com/api/extension-guides/overview
+- To connect with the VS Code extension developer community, please visit https://github.com/microsoft/vscode-discussions
+\n==========================`);
+  
 	program.parse(argv);
 };


### PR DESCRIPTION
Resolves #769 

## Description

This PR adds basic user-friendly message as a description, which is expected to appear at every command passed with the `--help` flag. The current `commander` version (6.1.0) doesn't support certain commands that help adding this message properly (like only for the 'root' help), as well as other commands that potentially can be helpful in optimizing the current code and removing the parts that `commander` has implemented under-the-hood (like showing suggestions on errors).
So I would highly suggest creating an issue to proceed with migration to version [8.2.0](https://github.com/tj/commander.js/releases/tag/v8.2.0) at least. And I would love to help you with that migration.