### PR TITLE
add a pack alias for package

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -81,6 +81,7 @@ module.exports = function (argv: string[]): void {
 
 	program
 		.command('package [version]')
+		.alias('pack')
 		.description('Packages an extension')
 		.option('-o, --out <path>', 'Output .vsix extension file to <path> location (defaults to <name>-<version>.vsix)')
 		.option('-t, --target <target>', `Target architecture. Valid targets: ${ValidTargets}`)


### PR DESCRIPTION
This trips me up every time I use vsce. npm uses 'npm pack', and vsce uses 'vsce package', so add an alias to save me a collective dozen seconds over the course of my life