### PR TITLE
Remove deprecated dependency punycode by updating markdown-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"hosted-git-info": "^4.0.2",
 		"jsonc-parser": "^3.2.0",
 		"leven": "^3.1.0",
-		"markdown-it": "^12.3.2",
+		"markdown-it": "^14.0.0",
 		"mime": "^1.3.4",
 		"minimatch": "^3.0.3",
 		"parse-semver": "^1.1.1",


### PR DESCRIPTION
This fixes https://github.com/microsoft/vscode-vsce/issues/930. I left package-lock.json untouched for now.