### PR TITLE
Use NodeApi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"azure-devops-node-api": "^11.0.1",
+				"azure-devops-node-api": "^12.5",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
 				"commander": "^6.2.1",
@@ -545,9 +545,9 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
 		},
 		"node_modules/azure-devops-node-api": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
-			"integrity": "sha512-XdiGPhrpaT5J8wdERRKs5g8E0Zy1pvOYTli7z9E8nmOn3YGp4FhtjhrOyFmX/8veWCwdI69mCHKJw6l+4J/bHA==",
+			"version": "12.5.0",
+			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+			"integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
 			"dependencies": {
 				"tunnel": "0.0.6",
 				"typed-rest-client": "^1.8.4"
@@ -3413,9 +3413,9 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
 		},
 		"azure-devops-node-api": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
-			"integrity": "sha512-XdiGPhrpaT5J8wdERRKs5g8E0Zy1pvOYTli7z9E8nmOn3YGp4FhtjhrOyFmX/8veWCwdI69mCHKJw6l+4J/bHA==",
+			"version": "12.5.0",
+			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+			"integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
 			"requires": {
 				"tunnel": "0.0.6",
 				"typed-rest-client": "^1.8.4"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"node": ">= 14"
 	},
 	"dependencies": {
-		"azure-devops-node-api": "^11.0.1",
+		"azure-devops-node-api": "^12.5",
 		"chalk": "^2.4.2",
 		"cheerio": "^1.0.0-rc.9",
 		"commander": "^6.2.1",

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -251,10 +251,7 @@ async function _publish(packagePath: string, sigzipPath: string | undefined, man
 }
 
 async function _publishSignedPackage(api: GalleryApi, packageName: string, packageStream: fs.ReadStream, sigzipName: string, sigzipStream: fs.ReadStream, manifest: Manifest) {
-	const apiVersion = '7.2-preview.1';
-	const url = encodeURI(`${api.baseUrl}/_apis/gallery/publishers/${manifest.publisher}/publishersignedextension/${manifest.name}?extensionType=Visual Studio Code&api-version=${apiVersion}&reCaptchaToken=`);
-	const requestOptions = api.createRequestOptions('application/json', apiVersion);
-
+	const extensionType = 'Visual Studio Code';
 	const form = new FormData();
 	const lineBreak = '\r\n';
 	form.setBoundary('0f411892-ef48-488f-89d3-4f0546e84723');
@@ -264,13 +261,8 @@ async function _publishSignedPackage(api: GalleryApi, packageName: string, packa
 	form.append('sigzip', sigzipStream, {
 		header: `--${form.getBoundary()}${lineBreak}Content-Disposition: attachment; name=sigzip; filename=${sigzipName}${lineBreak}Content-Type: application/octet-stream${lineBreak}${lineBreak}`
 	});
-	requestOptions.additionalHeaders = {
-		...form.getHeaders(),
-		'Content-Type': `multipart/related; boundary=${form.getBoundary()}`
-	};
 
-	const response = await api.rest.uploadStream('PUT', url, form, requestOptions);
-	return api.formatResponse(response.result, {}, false);
+	return await api.publishExtensionWithPublisherSignature(undefined, form, manifest.publisher, manifest.name, extensionType);
 }
 
 export interface IUnpublishOptions extends IPublishOptions {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
-import { read, getGalleryAPI, getSecurityRolesAPI, log } from './util';
+import { read, getGalleryAPI, getSecurityRolesAPI, log, getMarketplaceUrl } from './util';
 import { validatePublisher } from './validation';
 import { readManifest } from './package';
 
@@ -142,7 +142,7 @@ export async function verifyPat(pat: string, publisherName?: string): Promise<vo
 }
 
 async function requestPAT(publisherName: string): Promise<string> {
-	console.log('https://marketplace.visualstudio.com/manage/publishers/');
+	console.log(`${getMarketplaceUrl()}/manage/publishers/`);
 
 	const pat = await read(`Personal Access Token for publisher '${publisherName}':`, { silent: true, replace: '*' });
 	await verifyPat(pat, publisherName);

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,6 +23,10 @@ export function getPublishedUrl(extension: string): string {
 	return `${marketplaceUrl}/items?itemName=${extension}`;
 }
 
+export function getMarketplaceUrl(): string {
+	return marketplaceUrl;
+}
+
 export function getHubUrl(publisher: string, name: string): string {
 	return `${marketplaceUrl}/manage/publishers/${publisher}/extensions/${name}/hub`;
 }


### PR DESCRIPTION
Change to use to the new azure-devops-node-api method for calling publisher signing endpoint.