### PR TITLE
Retry on API request timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"azure-devops-node-api": "^12.5.0",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
+				"cockatiel": "^3.1.2",
 				"commander": "^6.2.1",
 				"form-data": "^4.0.0",
 				"glob": "^7.0.6",
@@ -774,6 +775,14 @@
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cockatiel": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.1.2.tgz",
+			"integrity": "sha512-5yARKww0dWyWg2/3xZeXgoxjHLwpVqFptj9Zy7qioJ6+/L0ARM184sgMUrQDjxw7ePJWlGhV998mKhzrxT0/Kg==",
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/code-point-at": {
@@ -3564,6 +3573,11 @@
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
 			}
+		},
+		"cockatiel": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.1.2.tgz",
+			"integrity": "sha512-5yARKww0dWyWg2/3xZeXgoxjHLwpVqFptj9Zy7qioJ6+/L0ARM184sgMUrQDjxw7ePJWlGhV998mKhzrxT0/Kg=="
 		},
 		"code-point-at": {
 			"version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"@types/mime": "^1",
 				"@types/minimatch": "^3.0.3",
 				"@types/mocha": "^7.0.2",
-				"@types/node": "^14.17.32",
+				"@types/node": "^16.0.0",
 				"@types/read": "^0.0.28",
 				"@types/semver": "^6.0.0",
 				"@types/tmp": "^0.2.2",
@@ -58,7 +58,7 @@
 				"typescript": "^4.3.2"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 16"
 			},
 			"optionalDependencies": {
 				"keytar": "^7.7.0"
@@ -341,9 +341,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "14.17.32",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-			"integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+			"version": "16.18.96",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.96.tgz",
+			"integrity": "sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ==",
 			"dev": true
 		},
 		"node_modules/@types/read": {
@@ -3225,9 +3225,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.17.32",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-			"integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+			"version": "16.18.96",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.96.tgz",
+			"integrity": "sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ==",
 			"dev": true
 		},
 		"@types/read": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"watch:test": "npm run test -- --watch"
 	},
 	"engines": {
-		"node": ">= 14"
+		"node": ">= 16"
 	},
 	"dependencies": {
 		"azure-devops-node-api": "^12.5.0",
@@ -70,7 +70,7 @@
 		"@types/mime": "^1",
 		"@types/minimatch": "^3.0.3",
 		"@types/mocha": "^7.0.2",
-		"@types/node": "^14.17.32",
+		"@types/node": "^16.11.7",
 		"@types/read": "^0.0.28",
 		"@types/semver": "^6.0.0",
 		"@types/tmp": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"azure-devops-node-api": "^12.5.0",
 		"chalk": "^2.4.2",
 		"cheerio": "^1.0.0-rc.9",
+		"cockatiel": "^3.1.2",
 		"commander": "^6.2.1",
 		"form-data": "^4.0.0",
 		"glob": "^7.0.6",

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -12,6 +12,7 @@ import { validatePublisher } from './validation';
 import { GalleryApi } from 'azure-devops-node-api/GalleryApi';
 import FormData from 'form-data';
 import { basename } from 'path';
+import { IterableBackoff, handleWhen, retry } from 'cockatiel';
 
 const tmpName = promisify(tmp.tmpName);
 
@@ -262,7 +263,14 @@ async function _publishSignedPackage(api: GalleryApi, packageName: string, packa
 		header: `--${form.getBoundary()}${lineBreak}Content-Disposition: attachment; name=sigzip; filename=${sigzipName}${lineBreak}Content-Type: application/octet-stream${lineBreak}${lineBreak}`
 	});
 
-	return await api.publishExtensionWithPublisherSignature(undefined, form, manifest.publisher, manifest.name, extensionType);
+	const publishWithRetry = retry(handleWhen(err => err.message.includes('timeout')), {
+		maxAttempts: 3,
+		backoff: new IterableBackoff([5_000, 10_000, 20_000])
+	});
+
+	return await publishWithRetry.execute(async () => {
+		return await api.publishExtensionWithPublisherSignature(undefined, form, manifest.publisher, manifest.name, extensionType);
+	});
 }
 
 export interface IUnpublishOptions extends IPublishOptions {


### PR DESCRIPTION
This pull request adds retry functionality to the publishing process in order to handle API request timeouts. Currently, when the connection between where `vsce` is running and the Marketplace API times out, the publishing fails. The proposed solution is to automatically retry the API request a few times with a backoff in between. 

For convinience, the `cockatiel` library was used which is why the node version had to be incresed to `>=16` 

fixes #926