### PR TITLE
fix: use namespace import for `glob` package

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -6,7 +6,7 @@ import * as yazl from 'yazl';
 import { ExtensionKind, Manifest } from './manifest';
 import { ITranslations, patchNLS } from './nls';
 import * as util from './util';
-import glob from 'glob';
+import * as glob from 'glob';
 import minimatch from 'minimatch';
 import markdownit from 'markdown-it';
 import * as cheerio from 'cheerio';
@@ -1567,7 +1567,7 @@ async function collectAllFiles(
 ): Promise<string[]> {
 	const deps = await getDependencies(cwd, dependencies, dependencyEntryPoints);
 	const promises = deps.map(dep =>
-		promisify(glob)('**', { cwd: dep, nodir: true, dot: true, ignore: 'node_modules/**' }).then(files =>
+		promisify(glob.default)('**', { cwd: dep, nodir: true, dot: true, ignore: 'node_modules/**' }).then(files =>
 			files.map(f => path.relative(cwd, path.join(dep, f))).map(f => f.replace(/\\/g, '/'))
 		)
 	);


### PR DESCRIPTION
I was getting an error from the `promisify(glob)` call, as the `glob` import was being resolved to undefined at runtime. Switching to a namespace import like `import * as glob` and changing the reference to `glob.default` has fixed the issue for me.

_Tested on Node v19, v20, and v21_
