### PR TITLE
enable signing in vsce using script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@azure/identity": "^4.1.0",
-				"@vscode/vsce-sign": "2.0.3",
+				"@vscode/vsce-sign": "^2.0.0",
 				"azure-devops-node-api": "^12.5.0",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@azure/identity": "^4.1.0",
+				"@vscode/vsce-sign": "2.0.3",
 				"azure-devops-node-api": "^12.5.0",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
@@ -596,6 +597,131 @@
 			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
 			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
 			"dev": true
+		},
+		"node_modules/@vscode/vsce-sign": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.3.tgz",
+			"integrity": "sha512-NYktTVXYIjJ41CTfImuWLYSw2UoZwYYFk7VcVYTjTZnD7NnuaM3DizaFZfuRG5YMRT/oZa1t1d4bwzrBALR3VQ==",
+			"hasInstallScript": true,
+			"optionalDependencies": {
+				"@vscode/vsce-sign-alpine-arm64": "2.0.1",
+				"@vscode/vsce-sign-alpine-x64": "2.0.1",
+				"@vscode/vsce-sign-darwin-arm64": "2.0.1",
+				"@vscode/vsce-sign-darwin-x64": "2.0.1",
+				"@vscode/vsce-sign-linux-arm": "2.0.1",
+				"@vscode/vsce-sign-linux-arm64": "2.0.1",
+				"@vscode/vsce-sign-linux-x64": "2.0.1",
+				"@vscode/vsce-sign-win32-arm64": "2.0.1",
+				"@vscode/vsce-sign-win32-x64": "2.0.1"
+			}
+		},
+		"node_modules/@vscode/vsce-sign-alpine-arm64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.1.tgz",
+			"integrity": "sha512-HM2BHzyRKoUHVaaVmLFYcKlnMOcUAfU99oA1yAWX46D6iLZ8rWJYy2IOKTSMOXtVoc5d2hQdZR4+BCV5By4Flg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"alpine"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-alpine-x64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.1.tgz",
+			"integrity": "sha512-GNh4dNmqwQqEDP2ngUgdu5ZYkJZAHomTppMI0v9sveFoZdML5iWuNGemvCEyInUpSb6Xjxc78ejeMoDay22wBw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"alpine"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-darwin-arm64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.1.tgz",
+			"integrity": "sha512-iFnCbC8RBUyT0ZKEmop5yi7/NxP5G2gIW/giJHYDYppkhfyAR5STxlpf8Vx9hqIS0jPbeldNSn5a5BGMKtGXug==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-darwin-x64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.1.tgz",
+			"integrity": "sha512-Dpv3PRpOzfDpji9JGVxe+hHyh41evyquMeXYykkTdcB3u3bZMoAgYoBlEOGnu87xb4s2J5DTj/J590yN0+dI0A==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-linux-arm": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.1.tgz",
+			"integrity": "sha512-iltMQuS8K63aIabVrPBB8P2L37XkSwUqPTFLYlH6Bw+UpWJTFFvFFCKlmbxWrq1j8WkG+68Fm437ZfAkRW/rjQ==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-linux-arm64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.1.tgz",
+			"integrity": "sha512-SL6MeobrArp5SKPeUYVr5chp7a42L83vYAzLvD+oQM8fQ8DrZWYpNIyVkxGgsppZRyAt0UU2/5ShPxuNKfnZOA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-linux-x64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.1.tgz",
+			"integrity": "sha512-6N6dkZoJX/WKezZ3efCKVKjnbx+TlnUtNUkepyUUhCa3dGjGDqUkeakE2Kz266Bsp0Mm/68zS9HLKVOEv9vn0A==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-win32-arm64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.1.tgz",
+			"integrity": "sha512-t4uYPpQummrmKaDw5Ka6QMEQ+We/Uo6xDEytFjN2jZ3jNOno3Mi7yWlTLg3VDAteHNGA7eBbMZ89Habl6xn8bg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-win32-x64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.1.tgz",
+			"integrity": "sha512-ofY1iXoXaNlM3zDt5jw7v59NMh0y2GvKrP4A74aUDJjaXaDd6n/hLaOpDLk4a+MjX6HWiEBr5yNqHGKYa+t2jg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/acorn": {
 			"version": "8.8.1",
@@ -3890,6 +4016,76 @@
 			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
 			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
 			"dev": true
+		},
+		"@vscode/vsce-sign": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.3.tgz",
+			"integrity": "sha512-NYktTVXYIjJ41CTfImuWLYSw2UoZwYYFk7VcVYTjTZnD7NnuaM3DizaFZfuRG5YMRT/oZa1t1d4bwzrBALR3VQ==",
+			"requires": {
+				"@vscode/vsce-sign-alpine-arm64": "2.0.1",
+				"@vscode/vsce-sign-alpine-x64": "2.0.1",
+				"@vscode/vsce-sign-darwin-arm64": "2.0.1",
+				"@vscode/vsce-sign-darwin-x64": "2.0.1",
+				"@vscode/vsce-sign-linux-arm": "2.0.1",
+				"@vscode/vsce-sign-linux-arm64": "2.0.1",
+				"@vscode/vsce-sign-linux-x64": "2.0.1",
+				"@vscode/vsce-sign-win32-arm64": "2.0.1",
+				"@vscode/vsce-sign-win32-x64": "2.0.1"
+			}
+		},
+		"@vscode/vsce-sign-alpine-arm64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.1.tgz",
+			"integrity": "sha512-HM2BHzyRKoUHVaaVmLFYcKlnMOcUAfU99oA1yAWX46D6iLZ8rWJYy2IOKTSMOXtVoc5d2hQdZR4+BCV5By4Flg==",
+			"optional": true
+		},
+		"@vscode/vsce-sign-alpine-x64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.1.tgz",
+			"integrity": "sha512-GNh4dNmqwQqEDP2ngUgdu5ZYkJZAHomTppMI0v9sveFoZdML5iWuNGemvCEyInUpSb6Xjxc78ejeMoDay22wBw==",
+			"optional": true
+		},
+		"@vscode/vsce-sign-darwin-arm64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.1.tgz",
+			"integrity": "sha512-iFnCbC8RBUyT0ZKEmop5yi7/NxP5G2gIW/giJHYDYppkhfyAR5STxlpf8Vx9hqIS0jPbeldNSn5a5BGMKtGXug==",
+			"optional": true
+		},
+		"@vscode/vsce-sign-darwin-x64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.1.tgz",
+			"integrity": "sha512-Dpv3PRpOzfDpji9JGVxe+hHyh41evyquMeXYykkTdcB3u3bZMoAgYoBlEOGnu87xb4s2J5DTj/J590yN0+dI0A==",
+			"optional": true
+		},
+		"@vscode/vsce-sign-linux-arm": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.1.tgz",
+			"integrity": "sha512-iltMQuS8K63aIabVrPBB8P2L37XkSwUqPTFLYlH6Bw+UpWJTFFvFFCKlmbxWrq1j8WkG+68Fm437ZfAkRW/rjQ==",
+			"optional": true
+		},
+		"@vscode/vsce-sign-linux-arm64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.1.tgz",
+			"integrity": "sha512-SL6MeobrArp5SKPeUYVr5chp7a42L83vYAzLvD+oQM8fQ8DrZWYpNIyVkxGgsppZRyAt0UU2/5ShPxuNKfnZOA==",
+			"optional": true
+		},
+		"@vscode/vsce-sign-linux-x64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.1.tgz",
+			"integrity": "sha512-6N6dkZoJX/WKezZ3efCKVKjnbx+TlnUtNUkepyUUhCa3dGjGDqUkeakE2Kz266Bsp0Mm/68zS9HLKVOEv9vn0A==",
+			"optional": true
+		},
+		"@vscode/vsce-sign-win32-arm64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.1.tgz",
+			"integrity": "sha512-t4uYPpQummrmKaDw5Ka6QMEQ+We/Uo6xDEytFjN2jZ3jNOno3Mi7yWlTLg3VDAteHNGA7eBbMZ89Habl6xn8bg==",
+			"optional": true
+		},
+		"@vscode/vsce-sign-win32-x64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.1.tgz",
+			"integrity": "sha512-ofY1iXoXaNlM3zDt5jw7v59NMh0y2GvKrP4A74aUDJjaXaDd6n/hLaOpDLk4a+MjX6HWiEBr5yNqHGKYa+t2jg==",
+			"optional": true
 		},
 		"acorn": {
 			"version": "8.8.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 	},
 	"dependencies": {
 		"@azure/identity": "^4.1.0",
+		"@vscode/vsce-sign": "2.0.3",
 		"azure-devops-node-api": "^12.5.0",
 		"chalk": "^2.4.2",
 		"cheerio": "^1.0.0-rc.9",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	},
 	"dependencies": {
 		"@azure/identity": "^4.1.0",
-		"@vscode/vsce-sign": "2.0.3",
+		"@vscode/vsce-sign": "^2.0.0",
 		"azure-devops-node-api": "^12.5.0",
 		"chalk": "^2.4.2",
 		"cheerio": "^1.0.0-rc.9",

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,7 +117,7 @@ module.exports = function (argv: string[]): void {
 		.option('--allow-star-activation', 'Allow using * in activation events')
 		.option('--allow-missing-repository', 'Allow missing a repository URL in package.json')
 		.option('--skip-license', 'Allow packaging without license file')
-		.option('--sign', 'Script to sign the VSIX package. VSIX manifest will be passed as an argument.')
+		.option('--sign', 'Script to sign the VSIX package. VSIX manifest will be passed as an argument. Generates <package-name>.signature.zip alongside the VSIX package.')
 		.action(
 			(
 				version,

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,7 +117,7 @@ module.exports = function (argv: string[]): void {
 		.option('--allow-star-activation', 'Allow using * in activation events')
 		.option('--allow-missing-repository', 'Allow missing a repository URL in package.json')
 		.option('--skip-license', 'Allow packaging without license file')
-		.option('--signtool', 'Path to the VSIX signing tool. Will be invoked with two arguments: `SIGNTOOL <path/to/extension.signature.manifest> <path/to/extension.signature.p7s>`.')
+		.option('--sign-tool', 'Path to the VSIX signing tool. Will be invoked with two arguments: `SIGNTOOL <path/to/extension.signature.manifest> <path/to/extension.signature.p7s>`.')
 		.action(
 			(
 				version,
@@ -144,7 +144,7 @@ module.exports = function (argv: string[]): void {
 					allowStarActivation,
 					allowMissingRepository,
 					skipLicense,
-					sign,
+					signTool,
 				}
 			) =>
 				main(
@@ -172,7 +172,7 @@ module.exports = function (argv: string[]): void {
 						allowStarActivation,
 						allowMissingRepository,
 						skipLicense,
-						sign,
+						signTool,
 					})
 				)
 		);
@@ -198,7 +198,7 @@ module.exports = function (argv: string[]): void {
 		.option('--no-update-package-json', 'Do not update `package.json`. Valid only when [version] is provided.')
 		.option('-i, --packagePath <paths...>', 'Publish the provided VSIX packages.')
 		.option('--sigzipPath <paths...>', 'Signature archives to publish alongside the VSIX packages.')
-		.option('--sign', 'Script to sign the VSIX package. VSIX manifest will be passed as an argument. This will be ignored if --sigzipPath is provided.')
+		.option('--sign-tool', 'Path to the VSIX signing tool. Will be invoked with two arguments: `SIGNTOOL <path/to/extension.signature.manifest> <path/to/extension.signature.p7s>`. This will be ignored if --sigzipPath is provided.')
 		.option(
 			'--githubBranch <branch>',
 			'The GitHub branch used to infer relative links in README.md. Can be overridden by --baseContentUrl and --baseImagesUrl.'
@@ -253,7 +253,7 @@ module.exports = function (argv: string[]): void {
 					allowMissingRepository,
 					skipDuplicate,
 					skipLicense,
-					sign,
+					signTool,
 				}
 			) =>
 				main(
@@ -285,7 +285,7 @@ module.exports = function (argv: string[]): void {
 						allowMissingRepository,
 						skipDuplicate,
 						skipLicense,
-						sign
+						signTool
 					})
 				)
 		);

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,6 +117,7 @@ module.exports = function (argv: string[]): void {
 		.option('--allow-star-activation', 'Allow using * in activation events')
 		.option('--allow-missing-repository', 'Allow missing a repository URL in package.json')
 		.option('--skip-license', 'Allow packaging without license file')
+		.option('--sign', 'Script to sign the VSIX package. VSIX manifest will be passed as an argument.')
 		.action(
 			(
 				version,
@@ -143,6 +144,7 @@ module.exports = function (argv: string[]): void {
 					allowStarActivation,
 					allowMissingRepository,
 					skipLicense,
+					sign,
 				}
 			) =>
 				main(
@@ -170,6 +172,7 @@ module.exports = function (argv: string[]): void {
 						allowStarActivation,
 						allowMissingRepository,
 						skipLicense,
+						sign,
 					})
 				)
 		);
@@ -195,6 +198,7 @@ module.exports = function (argv: string[]): void {
 		.option('--no-update-package-json', 'Do not update `package.json`. Valid only when [version] is provided.')
 		.option('-i, --packagePath <paths...>', 'Publish the provided VSIX packages.')
 		.option('--sigzipPath <paths...>', 'Signature archives to publish alongside the VSIX packages.')
+		.option('--sign', 'Script to sign the VSIX package. VSIX manifest will be passed as an argument. This will be ignored if --sigzipPath is provided.')
 		.option(
 			'--githubBranch <branch>',
 			'The GitHub branch used to infer relative links in README.md. Can be overridden by --baseContentUrl and --baseImagesUrl.'
@@ -249,6 +253,7 @@ module.exports = function (argv: string[]): void {
 					allowMissingRepository,
 					skipDuplicate,
 					skipLicense,
+					sign,
 				}
 			) =>
 				main(
@@ -280,6 +285,7 @@ module.exports = function (argv: string[]): void {
 						allowMissingRepository,
 						skipDuplicate,
 						skipLicense,
+						sign
 					})
 				)
 		);

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,7 +117,7 @@ module.exports = function (argv: string[]): void {
 		.option('--allow-star-activation', 'Allow using * in activation events')
 		.option('--allow-missing-repository', 'Allow missing a repository URL in package.json')
 		.option('--skip-license', 'Allow packaging without license file')
-		.option('--sign', 'Script to sign the VSIX package. VSIX manifest will be passed as an argument. Generates <package-name>.signature.zip alongside the VSIX package.')
+		.option('--signtool', 'Path to the VSIX signing tool. Will be invoked with two arguments: `SIGNTOOL <path/to/extension.signature.manifest> <path/to/extension.signature.p7s>`.')
 		.action(
 			(
 				version,

--- a/src/package.ts
+++ b/src/package.ts
@@ -1860,7 +1860,7 @@ export async function signPackage(packagePath: string, signScript: string): Prom
 		});
 	});
 	const signatureFile = path.join(path.dirname(packagePath), '.signature.p7s');
-	return zip(manifestPath, signatureFile);
+	return zip(manifestPath, signatureFile, path.basename(packagePath, '.vsix') + '.signature.zip');
 }
 
 export async function packageCommand(options: IPackageOptions = {}): Promise<any> {

--- a/src/package.ts
+++ b/src/package.ts
@@ -153,7 +153,7 @@ export interface IPackageOptions {
 	readonly allowMissingRepository?: boolean;
 	readonly skipLicense?: boolean;
 
-	readonly sign?: string;
+	readonly signTool?: string;
 }
 
 export interface IProcessor {
@@ -1867,8 +1867,8 @@ export async function packageCommand(options: IPackageOptions = {}): Promise<any
 
 	const { packagePath, files } = await pack(options);
 
-	if (options.sign) {
-		await signPackage(packagePath, options.sign);
+	if (options.signTool) {
+		await signPackage(packagePath, options.signTool);
 	}
 
 	const stats = await fs.promises.stat(packagePath);

--- a/src/package.ts
+++ b/src/package.ts
@@ -1855,7 +1855,7 @@ export async function signPackage(packagePath: string, signScript: string): Prom
 			}
 			return c();
 		});
-		proc.stdout!.on('data', (data) => {
+		proc.stdout?.on('data', (data) => {
 			console.log(data.toString('utf8'));
 		});
 	});

--- a/src/package.ts
+++ b/src/package.ts
@@ -1860,7 +1860,7 @@ export async function signPackage(packagePath: string, signScript: string): Prom
 		});
 	});
 	const signatureFile = path.join(path.dirname(packagePath), '.signature.p7s');
-	return zip(packagePath, signatureFile);
+	return zip(manifestPath, signatureFile);
 }
 
 export async function packageCommand(options: IPackageOptions = {}): Promise<any> {

--- a/src/package.ts
+++ b/src/package.ts
@@ -1850,10 +1850,13 @@ export async function signPackage(packageFile: string, signScript: string): Prom
 	const signatureFile = path.join(packageFolder, `${packageName}.signature.p7s`);
 	const signatureZip = path.join(packageFolder, `${packageName}.signature.zip`);
 
+	// Generate the signature manifest file
 	await generateManifest(packageFile, manifestFile);
-	const { stdout } = await promisify(cp.execFile)(signScript, [manifestFile,  signatureFile]);
-	console.log(stdout);
 
+	// Sign the manifest file to generate the signature file
+	cp.spawnSync(signScript, [manifestFile,  signatureFile], { stdio: 'inherit' });
+
+	// Create a signature zip file containing the manifest and signature file
 	return zip(manifestFile, signatureFile, signatureZip);
 }
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -76,7 +76,7 @@ export interface IPublishOptions {
 	readonly skipLicense?: boolean;
 
 	readonly sigzipPath?: string[];
-	readonly sign?: string;
+	readonly signTool?: string;
 }
 
 export async function publish(options: IPublishOptions = {}): Promise<any> {
@@ -119,8 +119,8 @@ export async function publish(options: IPublishOptions = {}): Promise<any> {
 			validateMarketplaceRequirements(vsix.manifest, options);
 
 			let sigzipPath = options.sigzipPath?.[index];
-			if (!sigzipPath && options.sign) {
-				sigzipPath = await signPackage(packagePath, options.sign);
+			if (!sigzipPath && options.signTool) {
+				sigzipPath = await signPackage(packagePath, options.signTool);
 			}
 
 
@@ -141,13 +141,13 @@ export async function publish(options: IPublishOptions = {}): Promise<any> {
 			for (const target of options.targets) {
 				const packagePath = await tmpName();
 				const packageResult = await pack({ ...options, target, packagePath });
-				const sigzipPath = options.sign ? await signPackage(packagePath, options.sign) : undefined;
+				const sigzipPath = options.signTool ? await signPackage(packagePath, options.signTool) : undefined;
 				await _publish(packagePath, sigzipPath, packageResult.manifest, { ...options, target });
 			}
 		} else {
 			const packagePath = await tmpName();
 			const packageResult = await pack({ ...options, packagePath });
-			const sigzipPath = options.sign ? await signPackage(packagePath, options.sign) : undefined;
+			const sigzipPath = options.signTool ? await signPackage(packagePath, options.signTool) : undefined;
 			await _publish(packagePath, sigzipPath, packageResult.manifest, options);
 		}
 	}

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import { promisify } from 'util';
 import * as semver from 'semver';
 import { ExtensionQueryFlags, PublishedExtension } from 'azure-devops-node-api/interfaces/GalleryInterfaces';
-import { pack, readManifest, versionBump, prepublish } from './package';
+import { pack, readManifest, versionBump, prepublish, signPackage } from './package';
 import * as tmp from 'tmp';
 import { IVerifyPatOptions, getPublisher } from './store';
 import { getGalleryAPI, read, getPublishedUrl, log, getHubUrl, patchOptionsWithManifest, getAzureCredentialAccessToken } from './util';
@@ -76,6 +76,7 @@ export interface IPublishOptions {
 	readonly skipLicense?: boolean;
 
 	readonly sigzipPath?: string[];
+	readonly sign?: string;
 }
 
 export async function publish(options: IPublishOptions = {}): Promise<any> {
@@ -117,7 +118,13 @@ export async function publish(options: IPublishOptions = {}): Promise<any> {
 
 			validateMarketplaceRequirements(vsix.manifest, options);
 
-			await _publish(packagePath, options.sigzipPath?.[index], vsix.manifest, { ...options, target });
+			let sigzipPath = options.sigzipPath?.[index];
+			if (!sigzipPath && options.sign) {
+				sigzipPath = await signPackage(packagePath, options.sign);
+			}
+
+
+			await _publish(packagePath, sigzipPath, vsix.manifest, { ...options, target });
 		}
 	} else {
 		const cwd = options.cwd || process.cwd();
@@ -134,12 +141,14 @@ export async function publish(options: IPublishOptions = {}): Promise<any> {
 			for (const target of options.targets) {
 				const packagePath = await tmpName();
 				const packageResult = await pack({ ...options, target, packagePath });
-				await _publish(packagePath, undefined, packageResult.manifest, { ...options, target });
+				const sigzipPath = options.sign ? await signPackage(packagePath, options.sign) : undefined;
+				await _publish(packagePath, sigzipPath, packageResult.manifest, { ...options, target });
 			}
 		} else {
 			const packagePath = await tmpName();
 			const packageResult = await pack({ ...options, packagePath });
-			await _publish(packagePath, undefined, packageResult.manifest, options);
+			const sigzipPath = options.sign ? await signPackage(packagePath, options.sign) : undefined;
+			await _publish(packagePath, sigzipPath, packageResult.manifest, options);
 		}
 	}
 }


### PR DESCRIPTION
enable signing in vsce using script

- add `--sign` script argument for signing the manifest
- enable package and publish to sign the package using `@vscode/vsce-sign` package and sign script