### PR TITLE
Support signing related features

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import program from 'commander';
 import leven from 'leven';
-import { packageCommand, ls, Targets } from './package';
+import { packageCommand, ls, Targets, generateManifest } from './package';
 import { publish, unpublish } from './publish';
 import { show } from './show';
 import { search } from './search';
@@ -197,6 +197,8 @@ module.exports = function (argv: string[]): void {
 		)
 		.option('--no-update-package-json', 'Do not update `package.json`. Valid only when [version] is provided.')
 		.option('-i, --packagePath <paths...>', 'Publish the provided VSIX packages.')
+		.option('--manifestPath <paths...>', 'Manifest files to publish alongside the VSIX packages.')
+		.option('--signaturePath <paths...>', 'Signature files to publish alongside the VSIX packages.')
 		.option('--sigzipPath <paths...>', 'Signature archives to publish alongside the VSIX packages.')
 		.option('--sign-tool <path>', 'Path to the VSIX signing tool. Will be invoked with two arguments: `SIGNTOOL <path/to/extension.signature.manifest> <path/to/extension.signature.p7s>`. This will be ignored if --sigzipPath is provided.')
 		.option(
@@ -237,6 +239,8 @@ module.exports = function (argv: string[]): void {
 					gitTagVersion,
 					updatePackageJson,
 					packagePath,
+					manifestPath,
+					signaturePath,
 					sigzipPath,
 					githubBranch,
 					gitlabBranch,
@@ -269,6 +273,8 @@ module.exports = function (argv: string[]): void {
 						gitTagVersion,
 						updatePackageJson,
 						packagePath,
+						manifestPath,
+						signaturePath,
 						sigzipPath,
 						githubBranch,
 						gitlabBranch,
@@ -297,6 +303,19 @@ module.exports = function (argv: string[]): void {
 		.option('--azure-credential', 'Use Microsoft Entra ID for authentication')
 		.option('-f, --force', 'Skip confirmation prompt when unpublishing an extension')
 		.action((id, { pat, azureCredential, force }) => main(unpublish({ id, pat, azureCredential, force })));
+
+	program
+		.command('generate-manifest')
+		.description('Generates the extension manifest from the provided VSIX package.')
+		.requiredOption('-i, --packagePath <path>', 'Path to the VSIX package')
+		.option('-o, --out <path>', 'Output the extension manifest to <path> location (defaults to .signature.manifest)')
+		.action((
+			packagePath,
+			out
+		) =>
+			main(
+				generateManifest(packagePath, out)
+			));
 
 	program
 		.command('ls-publishers')

--- a/src/package.ts
+++ b/src/package.ts
@@ -24,7 +24,7 @@ import { detectYarn, getDependencies } from './npm';
 import * as GitHost from 'hosted-git-info';
 import parseSemver from 'parse-semver';
 import * as jsonc from 'jsonc-parser';
-import { generateManifest, zip } from '@vscode/vsce-sign';
+import * as vsceSign from '@vscode/vsce-sign';
 
 const MinimatchOptions: minimatch.IOptions = { dot: true };
 
@@ -1850,14 +1850,22 @@ export async function signPackage(packageFile: string, signTool: string): Promis
 	const signatureFile = path.join(packageFolder, `${packageName}.signature.p7s`);
 	const signatureZip = path.join(packageFolder, `${packageName}.signature.zip`);
 
-	// Generate the signature manifest file
 	await generateManifest(packageFile, manifestFile);
 
 	// Sign the manifest file to generate the signature file
 	cp.execSync(`${signTool} "${manifestFile}" "${signatureFile}"`, { stdio: 'inherit' });
 
-	// Create a signature zip file containing the manifest and signature file
-	return zip(manifestFile, signatureFile, signatureZip);
+	return createSignatureArchive(manifestFile, signatureFile, signatureZip);
+}
+
+// Generate the signature manifest file
+export function generateManifest(packageFile: string, outputFile?: string): Promise<string> {
+	return vsceSign.generateManifest(packageFile, outputFile);
+}
+
+// Create a signature zip file containing the manifest and signature file
+export async function createSignatureArchive(manifestFile: string, signatureFile: string, outputFile?: string): Promise<string> {
+	return vsceSign.zip(manifestFile, signatureFile, outputFile)
 }
 
 export async function packageCommand(options: IPackageOptions = {}): Promise<any> {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import { promisify } from 'util';
 import * as semver from 'semver';
 import { ExtensionQueryFlags, PublishedExtension } from 'azure-devops-node-api/interfaces/GalleryInterfaces';
-import { pack, readManifest, versionBump, prepublish, signPackage } from './package';
+import { pack, readManifest, versionBump, prepublish, signPackage, createSignatureArchive } from './package';
 import * as tmp from 'tmp';
 import { IVerifyPatOptions, getPublisher } from './store';
 import { getGalleryAPI, read, getPublishedUrl, log, getHubUrl, patchOptionsWithManifest, getAzureCredentialAccessToken } from './util';
@@ -76,6 +76,8 @@ export interface IPublishOptions {
 	readonly skipLicense?: boolean;
 
 	readonly sigzipPath?: string[];
+	readonly manifestPath?: string[];
+	readonly signaturePath?: string[];
 	readonly signTool?: string;
 }
 
@@ -87,6 +89,12 @@ export async function publish(options: IPublishOptions = {}): Promise<any> {
 			throw new Error(
 				`Both options not supported simultaneously: 'packagePath' and 'target'. Use 'vsce package --target <target>' to first create a platform specific package, then use 'vsce publish --packagePath <path>' to publish it.`
 			);
+		}
+
+		if (options.manifestPath || options.signaturePath) {
+			if (options.packagePath.length !== options.manifestPath?.length || options.packagePath.length !== options.signaturePath?.length) {
+				throw new Error(`Either all packages must be signed or none of them.`);
+			}
 		}
 
 		for (let index = 0; index < options.packagePath.length; index++) {
@@ -118,11 +126,18 @@ export async function publish(options: IPublishOptions = {}): Promise<any> {
 
 			validateMarketplaceRequirements(vsix.manifest, options);
 
-			let sigzipPath = options.sigzipPath?.[index];
+			let sigzipPath: string | undefined;
+			if (options.manifestPath?.[index] && options.signaturePath?.[index]) {
+				sigzipPath = await createSignatureArchive(options.manifestPath[index], options.signaturePath[index])
+			}
+
+			if (!sigzipPath) {
+				sigzipPath = options.sigzipPath?.[index];
+			}
+
 			if (!sigzipPath && options.signTool) {
 				sigzipPath = await signPackage(packagePath, options.signTool);
 			}
-
 
 			await _publish(packagePath, sigzipPath, vsix.manifest, { ...options, target });
 		}


### PR DESCRIPTION
fix #993

Support following signing related features

- Generate the extension manifest from the extension vsix: `vsce generate-manifest --packagePath <package-path> --out <manifest-output-path>`
- Publish the extension with signed manifest: `vsce publish --packagePath <package-path> --manifestPath <manifest-path> --signaturePath <signature-path>` 

