### PR TITLE
Update Dockerfile to use node:18-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:18-alpine
 RUN apk add --update-cache \
     libsecret \
   && rm -rf /var/cache/apk/*


### PR DESCRIPTION
The Dockerfile is currently using `node:14-alpine` as the base image, which is not compatible with the required Node.js version of >= 18.x.x stated in the README. This results in a broken image. This pull request updates the Dockerfile to use `node:18-alpine` as the base image, resolving the issue.