### PR TITLE
fix: probabilistic trigger v8 crash

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -158,7 +158,7 @@ async function getYarnProductionDependencies(cwd: string, packagedDependencies?:
 	const raw = await new Promise<string>((c, e) =>
 		cp.exec(
 			'yarn list --prod --json',
-			{ cwd, encoding: 'utf8', env: { ...process.env }, maxBuffer: 5000 * 1024 },
+			{ cwd, encoding: 'utf8', env: { DISABLE_V8_COMPILE_CACHE: "1", ...process.env }, maxBuffer: 5000 * 1024 },
 			(err, stdout) => (err ? e(err) : c(stdout))
 		)
 	);


### PR DESCRIPTION
There is a probability of triggering a v8 crash when running the `yarn list --prod --json` command. Related discussion: https://github.com/nodejs/node/issues/51555

This issue does not always occur. When we build `vscode-reh-linux-arm64` in the Dockerfile, there is more than a 50% chance of failure.

If this PR is merged, the code related to DISABLE_V8_COMPILE_CACHE in vscode can also be removed (https://github.com/search?q=repo%3Amicrosoft%2Fvscode%20DISABLE_V8_COMPILE_CACHE&type=code).

Globally setting `DISABLE_V8_COMPILE_CACHE=1` will increase the entire build time by 3~5 minutes.

People possibly related to this: @deepak1556 