### PR TITLE
Allow packaging extension without a publisher

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -68,7 +68,7 @@ export interface ManifestPackage {
 	// mandatory (npm)
 	name: string;
 	version: string;
-	engines: { [name: string]: string };
+	engines: { vscode: string;[name: string]: string };
 
 	// vscode
 	publisher?: string;
@@ -129,3 +129,9 @@ export interface ManifestPackage {
 export interface ManifestPublish extends ManifestPackage {
 	publisher: string;
 }
+
+type RecursivePartial<T> = {
+	[P in keyof T]?: T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
+
+export type UnverifiedManifest = RecursivePartial<ManifestPackage>;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -64,14 +64,14 @@ export interface Contributions {
 
 export type ExtensionKind = 'ui' | 'workspace' | 'web';
 
-export interface Manifest {
+export interface ManifestPackage {
 	// mandatory (npm)
 	name: string;
 	version: string;
 	engines: { [name: string]: string };
 
 	// vscode
-	publisher: string;
+	publisher?: string;
 	icon?: string;
 	contributes?: Contributions;
 	activationEvents?: string[];
@@ -124,4 +124,8 @@ export interface Manifest {
 	// cpu?: string[];
 	// preferGlobal
 	// publishConfig
+}
+
+export interface ManifestPublish extends ManifestPackage {
+	publisher: string;
 }

--- a/src/nls.ts
+++ b/src/nls.ts
@@ -1,4 +1,4 @@
-import { Manifest } from './manifest';
+import { ManifestPackage } from './manifest';
 
 export interface ITranslations {
 	[key: string]: string;
@@ -27,7 +27,7 @@ function createPatcher(translations: ITranslations): <T>(value: T) => T {
 	};
 }
 
-export function patchNLS(manifest: Manifest, translations: ITranslations): Manifest {
+export function patchNLS(manifest: ManifestPackage, translations: ITranslations): ManifestPackage {
 	const patcher = createPatcher(translations);
 	return JSON.parse(JSON.stringify(manifest, (_, value: any) => patcher(value)));
 }

--- a/src/package.ts
+++ b/src/package.ts
@@ -1268,7 +1268,11 @@ export class ValidationProcessor extends BaseProcessor {
 
 export function validateManifest(manifest: Manifest): Manifest {
 	validateExtensionName(manifest.name);
-	validatePublisher(manifest.publisher);
+
+	// allow users to package an extension without a publisher for testing reasons
+	if (manifest.publisher) {
+		validatePublisher(manifest.publisher);
+	}
 
 	if (!manifest.version) {
 		throw new Error('Manifest missing field: version');
@@ -1848,6 +1852,7 @@ async function getPackagePath(cwd: string, manifest: Manifest, options: IPackage
 
 export async function pack(options: IPackageOptions = {}): Promise<IPackageResult> {
 	const cwd = options.cwd || process.cwd();
+	console.log('packaging extension from:', cwd);
 	const manifest = await readManifest(cwd);
 	const files = await collect(manifest, options);
 
@@ -1895,6 +1900,7 @@ export async function createSignatureArchive(manifestFile: string, signatureFile
 
 export async function packageCommand(options: IPackageOptions = {}): Promise<any> {
 	const cwd = options.cwd || process.cwd();
+	console.log('packaging command extension from:', cwd);
 	const manifest = await readManifest(cwd);
 	util.patchOptionsWithManifest(options, manifest);
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -1852,7 +1852,6 @@ async function getPackagePath(cwd: string, manifest: Manifest, options: IPackage
 
 export async function pack(options: IPackageOptions = {}): Promise<IPackageResult> {
 	const cwd = options.cwd || process.cwd();
-	console.log('packaging extension from:', cwd);
 	const manifest = await readManifest(cwd);
 	const files = await collect(manifest, options);
 
@@ -1900,7 +1899,6 @@ export async function createSignatureArchive(manifestFile: string, signatureFile
 
 export async function packageCommand(options: IPackageOptions = {}): Promise<any> {
 	const cwd = options.cwd || process.cwd();
-	console.log('packaging command extension from:', cwd);
 	const manifest = await readManifest(cwd);
 	util.patchOptionsWithManifest(options, manifest);
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -121,7 +121,7 @@ export interface IVerifyPatOptions {
 }
 
 export async function verifyPat(options: IVerifyPatOptions): Promise<void> {
-	const publisherName = options.publisherName ?? (await readManifest()).publisher;
+	const publisherName = options.publisherName ?? validatePublisher((await readManifest()).publisher);
 	const pat = await getPAT(publisherName, options);
 
 	try {

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@ import { IGalleryApi, GalleryApi } from 'azure-devops-node-api/GalleryApi';
 import chalk from 'chalk';
 import { PublicGalleryAPI } from './publicgalleryapi';
 import { ISecurityRolesApi } from 'azure-devops-node-api/SecurityRolesApi';
-import { Manifest } from './manifest';
+import { ManifestPackage } from './manifest';
 import { EOL } from 'os';
 
 const __read = promisify<_read.Options, string>(_read);
@@ -171,7 +171,7 @@ export const log = {
 	error: _log.bind(null, LogMessageType.ERROR) as LogFn,
 };
 
-export function patchOptionsWithManifest(options: any, manifest: Manifest): void {
+export function patchOptionsWithManifest(options: any, manifest: ManifestPackage): void {
 	if (!manifest.vsce) {
 		return;
 	}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -3,7 +3,7 @@ import parseSemver from 'parse-semver';
 
 const nameRegex = /^[a-z0-9][a-z0-9\-]*$/i;
 
-export function validatePublisher(publisher: string): void {
+export function validatePublisher(publisher: string | undefined): string {
 	if (!publisher) {
 		throw new Error(
 			`Missing publisher name. Learn more: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#publishing-extensions`
@@ -15,9 +15,11 @@ export function validatePublisher(publisher: string): void {
 			`Invalid publisher name '${publisher}'. Expected the identifier of a publisher, not its human-friendly name. Learn more: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#publishing-extensions`
 		);
 	}
+
+	return publisher;
 }
 
-export function validateExtensionName(name: string): void {
+export function validateExtensionName(name: string | undefined): string {
 	if (!name) {
 		throw new Error(`Missing extension name`);
 	}
@@ -25,9 +27,11 @@ export function validateExtensionName(name: string): void {
 	if (!nameRegex.test(name)) {
 		throw new Error(`Invalid extension name '${name}'`);
 	}
+
+	return name;
 }
 
-export function validateVersion(version: string): void {
+export function validateVersion(version: string | undefined): string {
 	if (!version) {
 		throw new Error(`Missing extension version`);
 	}
@@ -35,9 +39,11 @@ export function validateVersion(version: string): void {
 	if (!semver.valid(version)) {
 		throw new Error(`Invalid extension version '${version}'`);
 	}
+
+	return version;
 }
 
-export function validateEngineCompatibility(version: string): void {
+export function validateEngineCompatibility(version: string | undefined): string {
 	if (!version) {
 		throw new Error(`Missing vscode engine compatibility version`);
 	}
@@ -45,6 +51,8 @@ export function validateEngineCompatibility(version: string): void {
 	if (!/^\*$|^(\^|>=)?((\d+)|x)\.((\d+)|x)\.((\d+)|x)(\-.*)?$/.test(version)) {
 		throw new Error(`Invalid vscode engine compatibility version '${version}'`);
 	}
+
+	return version;
 }
 
 /**

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,5 +1,5 @@
 import { Entry, open, ZipFile } from 'yauzl';
-import { ManifestPackage } from './manifest';
+import { ManifestPackage, UnverifiedManifest } from './manifest';
 import { parseXmlManifest, XMLManifest } from './xml';
 import { Readable } from 'stream';
 import { filePathToVsixPath } from './util';
@@ -61,7 +61,7 @@ export async function readVSIXPackage(packagePath: string): Promise<{ manifest: 
 		throw new Error('VSIX manifest not found');
 	}
 
-	const manifest = JSON.parse(rawManifest.toString('utf8')) as Partial<ManifestPackage>;
+	const manifest = JSON.parse(rawManifest.toString('utf8')) as UnverifiedManifest;
 	let manifestValidated;
 	try {
 		manifestValidated = validateManifestForPackaging(manifest);


### PR DESCRIPTION
This pull request includes changes to the validation of the publisher field in the package manifest. Previously, the validation was triggered even if no publisher was set. With this change, the validation is only performed if a publisher is specified, allowing users to package an extension without a publisher for testing purposes.

fixes #1029