### PR TITLE
Fix typo in option hint

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -2019,7 +2019,7 @@ export async function printAndValidatePackagedFiles(files: IFile[], cwd: string,
 			message += unusedIncludePatterns.map(p => `  - ${p}`).join('\n');
 			message += '\nRemove any include pattern which is not needed.\n';
 			message += `\n=> Run ${chalk.bold('vsce ls --tree')} to see all included files.\n`;
-			message += `=> Use ${chalk.bold('--allow-unused-files-patterns')} to skip this check`;
+			message += `=> Use ${chalk.bold('--allow-unused-files-pattern')} to skip this check`;
 			util.log.error(message);
 			process.exit(1);
 		}


### PR DESCRIPTION
# Description 

vsce package --help shows 
```
Usage: vsce package|pack [options] [version]

Packages an extension

Options:
  -o, --out <path>                Output .vsix extension file to <path> location (defaults to <name>-<version>.vsix)
...
  --allow-missing-repository      Allow missing a repository URL in package.json
  --allow-unused-files-pattern    Allow include patterns for the files field in package.json that does not match any file
...
```

But the errors messages says: 
```
The following include patterns in the "files" property in package.json do not match any files packaged in the extension:
  - LICENSE
Remove any include pattern which is not needed.

=> Run vsce ls --tree to see all included files.
=> Use --allow-unused-files-patterns to skip this check
``` 

This PR propoes to remove the "s" from the error message (because adding an s to the option would be a breaking change). 