### PR TITLE
Fix regression with workdir symlinks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -75,8 +75,9 @@ module.exports = function (argv: string[]): void {
 		.option('--dependencies', 'Enable dependency detection via npm or yarn', undefined)
 		.option('--no-dependencies', 'Disable dependency detection via npm or yarn', undefined)
 		.option('--readme-path <path>', 'Path to README file (defaults to README.md)')
-		.action(({ tree, yarn, packagedDependencies, ignoreFile, dependencies, readmePath }) =>
-			main(ls({ tree, useYarn: yarn, packagedDependencies, ignoreFile, dependencies, readmePath }))
+		.option('--follow-symlinks', 'Recurse into symlinked directories instead of treating them as files')
+		.action(({ tree, yarn, packagedDependencies, ignoreFile, dependencies, readmePath, followSymlinks }) =>
+			main(ls({ tree, useYarn: yarn, packagedDependencies, ignoreFile, dependencies, readmePath, followSymlinks }))
 		);
 
 	program
@@ -119,6 +120,7 @@ module.exports = function (argv: string[]): void {
 		.option('--allow-unused-files-pattern', 'Allow include patterns for the files field in package.json that does not match any file')
 		.option('--skip-license', 'Allow packaging without license file')
 		.option('--sign-tool <path>', 'Path to the VSIX signing tool. Will be invoked with two arguments: `SIGNTOOL <path/to/extension.signature.manifest> <path/to/extension.signature.p7s>`.')
+		.option('--follow-symlinks', 'Recurse into symlinked directories instead of treating them as files')
 		.action(
 			(
 				version,
@@ -147,6 +149,7 @@ module.exports = function (argv: string[]): void {
 					allowUnusedFilesPattern,
 					skipLicense,
 					signTool,
+					followSymlinks,
 				}
 			) =>
 				main(
@@ -176,6 +179,7 @@ module.exports = function (argv: string[]): void {
 						allowUnusedFilesPattern,
 						skipLicense,
 						signTool,
+						followSymlinks,
 					})
 				)
 		);
@@ -229,6 +233,7 @@ module.exports = function (argv: string[]): void {
 		.option('--allow-unused-files-pattern', 'Allow include patterns for the files field in package.json that does not match any file')
 		.option('--skip-duplicate', 'Fail silently if version already exists on the marketplace')
 		.option('--skip-license', 'Allow publishing without license file')
+		.option('--follow-symlinks', 'Recurse into symlinked directories instead of treating them as files')
 		.action(
 			(
 				version,
@@ -263,6 +268,7 @@ module.exports = function (argv: string[]): void {
 					skipDuplicate,
 					skipLicense,
 					signTool,
+					followSymlinks,
 				}
 			) =>
 				main(
@@ -297,7 +303,8 @@ module.exports = function (argv: string[]): void {
 						allowUnusedFilesPattern,
 						skipDuplicate,
 						skipLicense,
-						signTool
+						signTool,
+						followSymlinks
 					})
 				)
 		);

--- a/src/package.ts
+++ b/src/package.ts
@@ -1617,7 +1617,7 @@ async function collectAllFiles(
 ): Promise<string[]> {
 	const deps = await getDependencies(cwd, dependencies, dependencyEntryPoints);
 	const promises = deps.map(dep =>
-		glob('**', { cwd: dep, nodir: true, dot: true, ignore: 'node_modules/**' }).then(files =>
+		glob('**', { cwd: dep, nodir: true, follow: true, dot: true, ignore: 'node_modules/**' }).then(files =>
 			files.map(f => path.relative(cwd, path.join(dep, f))).map(f => f.replace(/\\/g, '/'))
 		)
 	);

--- a/src/package.ts
+++ b/src/package.ts
@@ -95,10 +95,15 @@ export interface IPackageOptions {
 	 * `target` is set. For example, if `target` is `linux-x64` and there are
 	 * folders named `win32-x64`, `darwin-arm64` or `web`, the files inside
 	 * those folders will be ignored.
-	 * 
+	 *
 	 * @default false
 	 */
 	readonly ignoreOtherTargetFolders?: boolean;
+
+	/**
+	 * Recurse into symlinked directories instead of treating them as files.
+	 */
+	readonly followSymlinks?: boolean;
 
 	readonly commitMessage?: string;
 	readonly gitTagVersion?: boolean;
@@ -1613,11 +1618,12 @@ const defaultIgnore = [
 async function collectAllFiles(
 	cwd: string,
 	dependencies: 'npm' | 'yarn' | 'none' | undefined,
-	dependencyEntryPoints?: string[]
+	dependencyEntryPoints?: string[],
+	followSymlinks:boolean = true
 ): Promise<string[]> {
 	const deps = await getDependencies(cwd, dependencies, dependencyEntryPoints);
 	const promises = deps.map(dep =>
-		glob('**', { cwd: dep, nodir: true, follow: true, dot: true, ignore: 'node_modules/**' }).then(files =>
+		glob('**', { cwd: dep, nodir: true, follow: followSymlinks, dot: true, ignore: 'node_modules/**' }).then(files =>
 			files.map(f => path.relative(cwd, path.join(dep, f))).map(f => f.replace(/\\/g, '/'))
 		)
 	);
@@ -1647,11 +1653,12 @@ function collectFiles(
 	ignoreFile?: string,
 	manifestFileIncludes?: string[],
 	readmePath?: string,
+	followSymlinks:boolean = false
 ): Promise<string[]> {
 	readmePath = readmePath ?? 'README.md';
 	const notIgnored = ['!package.json', `!${readmePath}`];
 
-	return collectAllFiles(cwd, dependencies, dependencyEntryPoints).then(files => {
+	return collectAllFiles(cwd, dependencies, dependencyEntryPoints, followSymlinks).then(files => {
 		files = files.filter(f => !/\r$/m.test(f));
 
 		return (
@@ -1666,7 +1673,7 @@ function collectFiles(
 							manifestFileIncludes ?
 								// include all files in manifestFileIncludes and ignore the rest
 								Promise.resolve(manifestFileIncludes.map(file => `!${file}`).concat(['**']).join('\n\r')) :
-								// "files" property not used in package.json 
+								// "files" property not used in package.json
 								Promise.resolve('')
 				)
 
@@ -1758,7 +1765,7 @@ export function collect(manifest: ManifestPackage, options: IPackageOptions = {}
 	const ignoreFile = options.ignoreFile || undefined;
 	const processors = createDefaultProcessors(manifest, options);
 
-	return collectFiles(cwd, getDependenciesOption(options), packagedDependencies, ignoreFile, manifest.files, options.readmePath).then(fileNames => {
+	return collectFiles(cwd, getDependenciesOption(options), packagedDependencies, ignoreFile, manifest.files, options.readmePath, options.followSymlinks).then(fileNames => {
 		const files = fileNames.map(f => ({ path: util.filePathToVsixPath(f), localPath: path.join(cwd, f) }));
 
 		return processFiles(processors, files);
@@ -1931,6 +1938,7 @@ export interface IListFilesOptions {
 	readonly dependencies?: boolean;
 	readonly prepublish?: boolean;
 	readonly readmePath?: string;
+	readonly followSymlinks?: boolean;
 }
 
 /**
@@ -1944,7 +1952,7 @@ export async function listFiles(options: IListFilesOptions = {}): Promise<string
 		await prepublish(cwd, manifest, options.useYarn);
 	}
 
-	return await collectFiles(cwd, getDependenciesOption(options), options.packagedDependencies, options.ignoreFile, manifest.files, options.readmePath);
+	return await collectFiles(cwd, getDependenciesOption(options), options.packagedDependencies, options.ignoreFile, manifest.files, options.readmePath, options.followSymlinks);
 }
 
 interface ILSOptions {
@@ -1954,6 +1962,7 @@ interface ILSOptions {
 	readonly ignoreFile?: string;
 	readonly dependencies?: boolean;
 	readonly readmePath?: string;
+	readonly followSymlinks?: boolean;
 }
 
 /**
@@ -2008,7 +2017,7 @@ export async function printAndValidatePackagedFiles(files: IFile[], cwd: string,
 		util.log.error(message);
 		process.exit(1);
 	}
-	// Throw an error if the extension uses the files property in package.json and 
+	// Throw an error if the extension uses the files property in package.json and
 	// the package does not include at least one file for each include pattern
 	else if (manifest.files !== undefined && manifest.files.length > 0 && !options.allowUnusedFilesPattern) {
 		const localPaths = (files.filter(f => !isInMemoryFile(f)) as ILocalFile[]).map(f => util.normalize(f.localPath));

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -59,6 +59,11 @@ export interface IPublishOptions {
 	readonly ignoreFile?: string;
 
 	/**
+	 * Recurse into symlinked directories instead of treating them as files
+	 */
+	readonly followSymlinks?: boolean;
+
+	/**
 	 * The Personal Access Token to use.
 	 *
 	 * Defaults to the stored one.


### PR DESCRIPTION
See my comment in https://github.com/microsoft/vscode-vsce/issues/580#issuecomment-2357922938
While upgrading from vsce 2.3 to 3.1, I had this regression which prevented building my package.
I use the following `package.json` extract:
```json
  "workspaces": [
    "src/lib"
  ]
```
And this folder is a symlink.

If a workdir was refering a symlink directory, we would pass it to yazl, which would error out because it's a directory.

glob recommends using `follow: true` to consider directory symlinks as directories in the collection.