### PR TITLE
added unpublish to api.ts

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -108,6 +108,12 @@ export function publishVSIX(packagePath: string | string[], options: IPublishVSI
 }
 
 /**
+ * Options for the `unpublish` function.
+ * @public
+ */
+export type { IUnpublishOptions } from './publish';
+
+/**
  * Unpublishes a live extension.
  * @public
  */

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { publish as _publish, IPublishOptions } from './publish';
+import { publish as _publish, IPublishOptions, unpublish as _unpublish, IUnpublishOptions } from './publish';
 import { packageCommand, listFiles as _listFiles, IPackageOptions } from './package';
 
 /**
@@ -105,4 +105,12 @@ export function publishVSIX(packagePath: string | string[], options: IPublishVSI
 		targets: typeof options.target === 'string' ? [options.target] : undefined,
 		...{ target: undefined },
 	});
+}
+
+/**
+ * Unpublishes a live extension.
+ * @public
+ */
+export function unpublish(options: IUnpublishOptions = {}): Promise<any> {
+    return _unpublish(options);
 }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -289,6 +289,10 @@ async function _publishSignedPackage(api: GalleryApi, packageName: string, packa
 	});
 }
 
+/**
+ * Options for the `unpublish` function.
+ * @public
+ */
 export interface IUnpublishOptions extends IPublishOptions {
 	id?: string;
 	force?: boolean;


### PR DESCRIPTION
Hi there, this is my first PR to this library so I will check it over tomorrow and try to contribute tests if necessary.  My team manages a couple vscode extensions and publishes them using the node package.  Sometimes, we want to delete these extensions as well so I have this proposed change to add the `unpublish` function to `api.ts`.  Let me know what else needs to be done for this PR if I am missing anything, thanks!

**Changes**
- Exposes `unpublish` function through `api.ts`