### PR TITLE
Added unpublish to api.ts

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -108,19 +108,15 @@ export function publishVSIX(packagePath: string | string[], options: IPublishVSI
 }
 
 /**
- * Options for the `unpublish` function.
+ * Options for the `unpublishVSIX` function.
  * @public
  */
-export type { IUnpublishOptions } from './publish';
+export type IUnpublishVSIXOptions = IPublishOptions & Pick<IUnpublishOptions, 'id'>;
 
 /**
- * Unpublishes a live extension.
+ * Deletes a specific extension from the marketplace.
  * @public
  */
-export function unpublish(options: IUnpublishOptions = {}): Promise<any> {
-	if  (!options.force) {
-		options.force = true;
-	}
-
-    return _unpublish(options);
+export function unpublishVSIX(options: IUnpublishVSIXOptions = {}): Promise<any> {
+    return _unpublish({"force": true, ...options});
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { publish as _publish, IPublishOptions } from './publish';
+import { publish as _publish, IPublishOptions, unpublish as _unpublish, IUnpublishOptions } from './publish';
 import { packageCommand, listFiles as _listFiles, IPackageOptions } from './package';
 
 /**
@@ -105,4 +105,22 @@ export function publishVSIX(packagePath: string | string[], options: IPublishVSI
 		targets: typeof options.target === 'string' ? [options.target] : undefined,
 		...{ target: undefined },
 	});
+}
+
+/**
+ * Options for the `unpublish` function.
+ * @public
+ */
+export type { IUnpublishOptions } from './publish';
+
+/**
+ * Unpublishes a live extension.
+ * @public
+ */
+export function unpublish(options: IUnpublishOptions = {}): Promise<any> {
+	if  (!options.force) {
+		options.force = true;
+	}
+
+    return _unpublish(options);
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -118,5 +118,5 @@ export type IUnpublishVSIXOptions = IPublishOptions & Pick<IUnpublishOptions, 'i
  * @public
  */
 export function unpublishVSIX(options: IUnpublishVSIXOptions = {}): Promise<any> {
-    return _unpublish({"force": true, ...options});
+	return _unpublish({ force: true, ...options });
 }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -289,6 +289,10 @@ async function _publishSignedPackage(api: GalleryApi, packageName: string, packa
 	});
 }
 
+/**
+ * Options for the `unpublish` function.
+ * @public
+ */
 export interface IUnpublishOptions extends IPublishOptions {
 	id?: string;
 	force?: boolean;


### PR DESCRIPTION
Exposed unpublish function to the `api.ts` file so it can be used as a node package.  We personally use vsce this way.

Notes:
- Exposes `unpublish` function and `IUnpublishOptions`
- Makes the choice to default `force` to true for IUnpublishOptions because no prompt is available when running as a node package.