### PR TITLE
Change vsce update notification from INFO to WARNING

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ function main(task: Promise<any>): void {
 
 	task.catch(fatal).then(() => {
 		if (latestVersion && semver.gt(latestVersion, pkg.version)) {
-			log.info(`The latest version of ${pkg.name} is ${latestVersion} and you have ${pkg.version}.\nUpdate it now: npm install -g ${pkg.name}`);
+			log.warn(`The latest version of ${pkg.name} is ${latestVersion} and you have ${pkg.version}.\nUpdate it now: npm install -g ${pkg.name}`);
 		} else {
 			token.cancel();
 		}


### PR DESCRIPTION
This pull request updates the logging level for the notification regarding the `vsce` version being out of date from INFO to WARNING. This change aims to encourage users to keep their `vsce` installation up to date, enhancing overall user experience and ensuring they are using the latest features and fixes.

Fixes #1064