### PR TITLE
copilot should be github-copilot tag

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -675,7 +675,7 @@ export class TagsProcessor extends BaseProcessor {
 		const debuggers = doesContribute('debuggers') ? ['debuggers'] : [];
 		const json = doesContribute('jsonValidation') ? ['json'] : [];
 		const remoteMenu = doesContribute('menus', 'statusBar/remoteIndicator') ? ['remote-menu'] : [];
-		const chatParticipants = doesContribute('chatParticipants') ? ['chat-participant', 'copilot'] : [];
+		const chatParticipants = doesContribute('chatParticipants') ? ['chat-participant', 'github-copilot'] : [];
 
 		const localizationContributions = ((contributes && contributes['localizations']) ?? []).reduce<string[]>(
 			(r, l) => [...r, `lp-${l.languageId}`, ...toLanguagePackTags(l.translations, l.languageId)],

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1332,7 +1332,7 @@ describe('toVsixManifest', () => {
 			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'snippet,__web_extension'));
 	});
 
-	it('should automatically add chatParticipant and copilot tag', () => {
+	it('should automatically add chatParticipant and github-copilot tag', () => {
 		const manifest = {
 			name: 'test',
 			publisher: 'mocha',
@@ -1345,7 +1345,7 @@ describe('toVsixManifest', () => {
 
 		return _toVsixManifest(manifest, [])
 			.then(parseXmlManifest)
-			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'chat-participant,copilot,__web_extension'));
+			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'chat-participant,github-copilot,__web_extension'));
 	});
 
 	it('should remove duplicate tags', () => {


### PR DESCRIPTION
I made a mistake on Friday. The tag "copilot" is already widely used, we need something more specific.
I am renaming it here to be "github-copilot"

fyi @joaomoreno 

![Screenshot 2024-10-21 at 11 56 24](https://github.com/user-attachments/assets/8c8cd6b8-ee94-4249-89ce-33120c1cade5)
