### PR TITLE
Allow for reproducible .vsix packages

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -505,7 +505,7 @@ export class ManifestProcessor extends BaseProcessor {
 			if (!minEngineVersion) {
 				throw new Error('Failed to get minVersion of engines.vscode')
 			}
-			
+
 			if (target) {
 				if (engineSemver.version !== 'latest' && !semver.satisfies(minEngineVersion, '>=1.61', { includePrerelease: true })) {
 					throw new Error(
@@ -1796,7 +1796,7 @@ export function collect(manifest: ManifestPackage, options: IPackageOptions = {}
 	});
 }
 
-export function writeVsix(files: IFile[], packagePath: string): Promise<void> {
+function writeVsix(files: IFile[], packagePath: string): Promise<void> {
 	return fs.promises
 		.unlink(packagePath)
 		.catch(err => (err.code !== 'ENOENT' ? Promise.reject(err) : Promise.resolve(null)))


### PR DESCRIPTION
Running the same build produces .vsix package that have the same content, but are not bit for bit the same, making it somewhat complicated to verify reproducible builds. Two changes are needed to fix this:

1. The mtime of each file added to the .vsix archive is included in each archive entry, so builds that happen at different times will have different entry timestamps. To fix this, if the SOURCE_DATE_EPOCH environment variable is defined, it it now used as entry timestamp value instead. Builds will now be reproducible as long as they set the same SOURCE_DATE_EPOCH value. If the environment variable is not defined or is not an integer, the current behavior is used.
2. The order that files are collected in preparation for packaging into the .vsix file is non-deterministic, which can lead to archives with the same content but in different orders. To fix this, files are sorted by archive entry name prior to adding.

Fixes #906