### PR TITLE
Update command line parameters for consistency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
 				"cockatiel": "^3.1.2",
-				"commander": "^6.2.1",
+				"commander": "^12.1.0",
 				"form-data": "^4.0.0",
 				"glob": "^11.0.0",
 				"hosted-git-info": "^4.0.2",
@@ -1289,11 +1289,12 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+			"license": "MIT",
 			"engines": {
-				"node": ">= 6"
+				"node": ">=18"
 			}
 		},
 		"node_modules/concat-map": {
@@ -1320,9 +1321,10 @@
 			"dev": true
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -4881,9 +4883,9 @@
 			}
 		},
 		"commander": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -4909,9 +4911,9 @@
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"requires": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"chalk": "^2.4.2",
 		"cheerio": "^1.0.0-rc.9",
 		"cockatiel": "^3.1.2",
-		"commander": "^6.2.1",
+		"commander": "^12.1.0",
 		"form-data": "^4.0.0",
 		"glob": "^11.0.0",
 		"hosted-git-info": "^4.0.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import program from 'commander';
+import { Command, Option } from 'commander';
 import leven from 'leven';
 import { packageCommand, ls, Targets, generateManifest, verifySignature } from './package';
 import { publish, unpublish } from './publish';
@@ -56,6 +56,8 @@ function main(task: Promise<any>): void {
 const ValidTargets = [...Targets].join(', ');
 
 module.exports = function (argv: string[]): void {
+	const program = new Command();
+
 	program.version(pkg.version).usage('<command>');
 
 	program
@@ -220,7 +222,8 @@ module.exports = function (argv: string[]): void {
 		.option('--baseImagesUrl <url>', 'Prepend all relative image links in README.md with the specified URL.')
 		.option('--yarn', 'Use yarn instead of npm (default inferred from presence of yarn.lock or .yarnrc)')
 		.option('--no-yarn', 'Use npm instead of yarn (default inferred from absence of yarn.lock or .yarnrc)')
-		.option('--noVerify', 'Allow all proposed APIs (deprecated: use --allow-all-proposed-apis instead)')
+		.option('--no-verify', 'Allow all proposed APIs (deprecated: use --allow-all-proposed-apis instead)')
+		.addOption(new Option('--noVerify', 'Allow all proposed APIs (deprecated: use --allow-all-proposed-apis instead)').hideHelp(true))
 		.option('--allow-proposed-apis <apis...>', 'Allow specific proposed APIs')
 		.option('--allow-all-proposed-apis', 'Allow all proposed APIs')
 		.option('--ignoreFile <path>', 'Indicate alternative .vscodeignore')
@@ -256,6 +259,7 @@ module.exports = function (argv: string[]): void {
 					baseContentUrl,
 					baseImagesUrl,
 					yarn,
+					verify,
 					noVerify,
 					allowProposedApis,
 					allowAllProposedApis,
@@ -292,7 +296,7 @@ module.exports = function (argv: string[]): void {
 						baseContentUrl,
 						baseImagesUrl,
 						useYarn: yarn,
-						noVerify,
+						noVerify: noVerify || !verify,
 						allowProposedApis,
 						allowAllProposedApis,
 						ignoreFile,
@@ -387,7 +391,7 @@ module.exports = function (argv: string[]): void {
 		}
 
 		program.outputHelp(help => {
-			const availableCommands = program.commands.map(c => c._name);
+			const availableCommands = program.commands.map(c => c.name());
 			const suggestion = availableCommands.find(c => leven(c, cmd) < c.length * 0.4);
 
 			help = `${help}\n Unknown command '${cmd}'`;


### PR DESCRIPTION
Refactor command line parameters to ensure consistent styling, specifically changing `--noVerify` to `--no-verify`. Additionally, update the `commander` package to the latest version for better functionality.

Fixes #719