### PR TITLE
Support additional prepublish scripts for release and prerelease

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -156,7 +156,7 @@ export async function publish(options: IPublishOptions = {}): Promise<any> {
 		// Validate marketplace requirements before prepublish to avoid unnecessary work
 		validateManifestForPublishing(manifest, options);
 
-		await prepublish(cwd, manifest, options.useYarn);
+		await prepublish(cwd, manifest, options.useYarn, options.preRelease ? 'preRelease' : 'release');
 		await versionBump(options);
 
 		if (options.targets) {


### PR DESCRIPTION
Support `vscode:prepublish:release` and `vscode:prepublish:prerelease` scripts, allowing for more flexible package publishing options. 

#947