### PR TITLE
Remove unused 'github-copilot' tag

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -681,8 +681,8 @@ export class TagsProcessor extends BaseProcessor {
 		const debuggers = doesContribute('debuggers') ? ['debuggers'] : [];
 		const json = doesContribute('jsonValidation') ? ['json'] : [];
 		const remoteMenu = doesContribute('menus', 'statusBar/remoteIndicator') ? ['remote-menu'] : [];
-		const chatParticipants = doesContribute('chatParticipants') ? ['chat-participant', 'github-copilot'] : [];
-		const languageModelTool = doesContribute('languageModelTool') ? ['tools', 'github-copilot'] : [];
+		const chatParticipants = doesContribute('chatParticipants') ? ['chat-participant'] : [];
+		const languageModelTool = doesContribute('languageModelTool') ? ['tools'] : [];
 
 		const localizationContributions = ((contributes && contributes['localizations']) ?? []).reduce<string[]>(
 			(r, l) => [...r, `lp-${l.languageId}`, ...toLanguagePackTags(l.translations, l.languageId)],

--- a/src/package.ts
+++ b/src/package.ts
@@ -682,7 +682,7 @@ export class TagsProcessor extends BaseProcessor {
 		const json = doesContribute('jsonValidation') ? ['json'] : [];
 		const remoteMenu = doesContribute('menus', 'statusBar/remoteIndicator') ? ['remote-menu'] : [];
 		const chatParticipants = doesContribute('chatParticipants') ? ['chat-participant'] : [];
-		const languageModelTool = doesContribute('languageModelTool') ? ['tools'] : [];
+		const languageModelTools = doesContribute('languageModelTools') ? ['tools'] : [];
 
 		const localizationContributions = ((contributes && contributes['localizations']) ?? []).reduce<string[]>(
 			(r, l) => [...r, `lp-${l.languageId}`, ...toLanguagePackTags(l.translations, l.languageId)],
@@ -724,7 +724,7 @@ export class TagsProcessor extends BaseProcessor {
 			...json,
 			...remoteMenu,
 			...chatParticipants,
-			...languageModelTool,
+			...languageModelTools,
 			...localizationContributions,
 			...languageContributions,
 			...languageActivations,

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1333,7 +1333,7 @@ describe('toVsixManifest', () => {
 			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'snippet,__web_extension'));
 	});
 
-	it('should automatically add chatParticipant and github-copilot tag', () => {
+	it('should automatically add chatParticipant tag', () => {
 		const manifest = {
 			name: 'test',
 			publisher: 'mocha',
@@ -1346,7 +1346,23 @@ describe('toVsixManifest', () => {
 
 		return _toVsixManifest(manifest, [])
 			.then(parseXmlManifest)
-			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'chat-participant,github-copilot,__web_extension'));
+			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'chat-participant,__web_extension'));
+	});
+
+	it('should automatically add tools tag', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			engines: Object.create(null),
+			contributes: {
+				languageModelTools: [{ name: 'test', id: 'test' }],
+			},
+		};
+
+		return _toVsixManifest(manifest, [])
+			.then(parseXmlManifest)
+			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'tools,__web_extension'));
 	});
 
 	it('should remove duplicate tags', () => {


### PR DESCRIPTION
```Copilot Generated Description:``` Eliminate the 'github-copilot' tag from the chat participants and language model tool contributions as it is no longer used.

Fixes microsoft/vscode-vsce#1121