### PR TITLE
Make the [Content_Types].xml file deterministic

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -1601,8 +1601,14 @@ export async function toContentTypes(files: IFile[]): Promise<string> {
 		contentTypes.push(`<Default Extension="${extension}" ContentType="${contentType}"/>`);
 	}
 
+	// The files array passed into this function has non-deterministic order
+	// depending on filesystem directory traversal. This leads to the order of
+	// the "Default" elements changing from build to build, which prevents
+	// reproducible vsix files. To fix this, this sorts the contentTypes array
+	// to ensure they are listed in the same order regardless of the order of
+	// the files array.
 	return `<?xml version="1.0" encoding="utf-8"?>
-<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">${contentTypes.join('')}</Types>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">${contentTypes.sort().join('')}</Types>
 `;
 }
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -1607,8 +1607,10 @@ export async function toContentTypes(files: IFile[]): Promise<string> {
 	// reproducible vsix files. To fix this, this sorts the contentTypes array
 	// to ensure they are listed in the same order regardless of the order of
 	// the files array.
+	const sortedContentTypes = contentTypes.sort();
+
 	return `<?xml version="1.0" encoding="utf-8"?>
-<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">${contentTypes.sort().join('')}</Types>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">${sortedContentTypes.join('')}</Types>
 `;
 }
 


### PR DESCRIPTION
The order of the extension + mime types listed in the [Content_Types].xml file is dependent on the order files are listed in the files array, which can vary depending on the underlying filesystem's traversal order. This can lead to non-reproducible .vsix files.

This sorts the contentTypes array to ensure the order is always consistent and reproducible, regardless of the order of the files array, ensuring reproducible .vsix files.
