### PR TITLE
Add 'mcp' tag support in TagsProcessor

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -673,6 +673,7 @@ export class TagsProcessor extends BaseProcessor {
 		const remoteMenu = doesContribute('menus', 'statusBar/remoteIndicator') ? ['remote-menu'] : [];
 		const chatParticipants = doesContribute('chatParticipants') ? ['chat-participant'] : [];
 		const languageModelTools = doesContribute('languageModelTools') ? ['tools', 'language-model-tools'] : [];
+		const mcp = doesContribute('modelContextServerCollections') ? ['mcp'] : [];
 
 		const localizationContributions = ((contributes && contributes['localizations']) ?? []).reduce<string[]>(
 			(r, l) => [...r, `lp-${l.languageId}`, ...toLanguagePackTags(l.translations, l.languageId)],
@@ -715,6 +716,7 @@ export class TagsProcessor extends BaseProcessor {
 			...remoteMenu,
 			...chatParticipants,
 			...languageModelTools,
+			...mcp,
 			...localizationContributions,
 			...languageContributions,
 			...languageActivations,

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1365,6 +1365,22 @@ describe('toVsixManifest', () => {
 			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'tools,language-model-tools,__web_extension'));
 	});
 
+	it('should automatically add mcp tag', () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			engines: Object.create(null),
+			contributes: {
+				modelContextServerCollections: [{ label: 'test', id: 'test' }],
+			},
+		};
+
+		return _toVsixManifest(manifest, [])
+			.then(parseXmlManifest)
+			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'mcp,__web_extension'));
+	});
+
 	it('should remove duplicate tags', () => {
 		const manifest = {
 			name: 'test',


### PR DESCRIPTION
Introduce support for the 'mcp' tag in the TagsProcessor and add a corresponding test case to ensure correct functionality.

closes https://github.com/microsoft/vscode-vsce/issues/1134