### PR TITLE
Add `language-model-tools` tag for MCP extensions

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -673,7 +673,7 @@ export class TagsProcessor extends BaseProcessor {
 		const remoteMenu = doesContribute('menus', 'statusBar/remoteIndicator') ? ['remote-menu'] : [];
 		const chatParticipants = doesContribute('chatParticipants') ? ['chat-participant'] : [];
 		const languageModelTools = doesContribute('languageModelTools') ? ['tools', 'language-model-tools'] : [];
-		const mcp = doesContribute('modelContextServerCollections') ? ['mcp'] : [];
+		const mcp = doesContribute('modelContextServerCollections') ? ['mcp', 'language-model-tools'] : [];
 
 		const localizationContributions = ((contributes && contributes['localizations']) ?? []).reduce<string[]>(
 			(r, l) => [...r, `lp-${l.languageId}`, ...toLanguagePackTags(l.translations, l.languageId)],

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1378,7 +1378,7 @@ describe('toVsixManifest', () => {
 
 		return _toVsixManifest(manifest, [])
 			.then(parseXmlManifest)
-			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'mcp,__web_extension'));
+			.then(result => assert.deepEqual(result.PackageManifest.Metadata[0].Tags[0], 'mcp,language-model-tools,__web_extension'));
 	});
 
 	it('should remove duplicate tags', () => {


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce the `language-model-tools` tag for MCP extensions in the package configuration and update related tests to reflect this change.

closes https://github.com/microsoft/vscode-vsce/issues/1140