### PR TITLE
Allow packaging .env and secrets using command line flags

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -124,6 +124,9 @@ module.exports = function (argv: string[]): void {
 		.option('--allow-star-activation', 'Allow using * in activation events')
 		.option('--allow-missing-repository', 'Allow missing a repository URL in package.json')
 		.option('--allow-unused-files-pattern', 'Allow include patterns for the files field in package.json that does not match any file')
+		.option('--allow-package-secrets <secrets...>', 'Allow packaging specific secrets. The names of the secrets can be found in the error message ([SECRET_NAME]).')
+		.option('--allow-package-all-secrets', 'Allow to package all kinds of secrets')
+		.option('--allow-package-env-file', 'Allow packaging .env files')
 		.option('--skip-license', 'Allow packaging without license file')
 		.option('--sign-tool <path>', 'Path to the VSIX signing tool. Will be invoked with two arguments: `SIGNTOOL <path/to/extension.signature.manifest> <path/to/extension.signature.p7s>`.')
 		.option('--follow-symlinks', 'Recurse into symlinked directories instead of treating them as files')
@@ -153,6 +156,9 @@ module.exports = function (argv: string[]): void {
 					allowStarActivation,
 					allowMissingRepository,
 					allowUnusedFilesPattern,
+					allowPackageSecrets,
+					allowPackageAllSecrets,
+					allowPackageEnvFile,
 					skipLicense,
 					signTool,
 					followSymlinks,
@@ -183,6 +189,9 @@ module.exports = function (argv: string[]): void {
 						allowStarActivation,
 						allowMissingRepository,
 						allowUnusedFilesPattern,
+						allowPackageSecrets,
+						allowPackageAllSecrets,
+						allowPackageEnvFile,
 						skipLicense,
 						signTool,
 						followSymlinks,
@@ -230,6 +239,9 @@ module.exports = function (argv: string[]): void {
 		.addOption(new Option('--noVerify', 'Allow all proposed APIs (deprecated: use --allow-all-proposed-apis instead)').hideHelp(true))
 		.option('--allow-proposed-apis <apis...>', 'Allow specific proposed APIs')
 		.option('--allow-all-proposed-apis', 'Allow all proposed APIs')
+		.option('--allow-package-secrets <secrets...>', 'Allow packaging specific secrets. The names of the secrets can be found in the error message ([SECRET_NAME]).')
+		.option('--allow-package-all-secrets', 'Allow to package all kinds of secrets')
+		.option('--allow-package-env-file', 'Allow packaging .env files')
 		.option('--ignoreFile <path>', 'Indicate alternative .vscodeignore')
 		// default must remain undefined for dependencies or we will fail to load defaults from package.json
 		.option('--dependencies', 'Enable dependency detection via npm or yarn', undefined)
@@ -267,6 +279,9 @@ module.exports = function (argv: string[]): void {
 					noVerify,
 					allowProposedApis,
 					allowAllProposedApis,
+					allowPackageSecrets,
+					allowPackageAllSecrets,
+					allowPackageEnvFile,
 					ignoreFile,
 					dependencies,
 					preRelease,
@@ -303,6 +318,9 @@ module.exports = function (argv: string[]): void {
 						noVerify: noVerify || !verify,
 						allowProposedApis,
 						allowAllProposedApis,
+						allowPackageSecrets,
+						allowPackageAllSecrets,
+						allowPackageEnvFile,
 						ignoreFile,
 						dependencies,
 						preRelease,

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -74,6 +74,9 @@ export interface IPublishOptions {
 	readonly noVerify?: boolean;
 	readonly allowProposedApis?: string[];
 	readonly allowAllProposedApis?: boolean;
+	readonly allowPackageSecrets?: string[];
+	readonly allowPackageAllSecrets?: boolean;
+	readonly allowPackageEnvFile?: boolean;
 	readonly dependencies?: boolean;
 	readonly preRelease?: boolean;
 	readonly allowStarActivation?: boolean;

--- a/src/secretLint.ts
+++ b/src/secretLint.ts
@@ -74,6 +74,11 @@ function parseResult(result: SecretLintEngineResult): SecretLintResult {
 	return { ok: result.ok, results };
 }
 
+export function getRuleNameFromRuleId(ruleId: string): string {
+	const parts = ruleId.split('-rule-');
+	return parts[parts.length - 1];
+}
+
 export function prettyPrintLintResult(result: Result): string {
 	if (!result.message.text) {
 		return JSON.stringify(result);
@@ -82,7 +87,9 @@ export function prettyPrintLintResult(result: Result): string {
 	const text = result.message.text;
 	const titleColor = result.level === undefined || result.level === Level.Error ? chalk.bold.red : chalk.bold.yellow;
 	const title = text.length > 54 ? text.slice(0, 50) + '...' : text;
-	let output = `\t${titleColor(title)}\n`;
+	const ruleName = result.ruleId ? getRuleNameFromRuleId(result.ruleId) : 'unknown';
+
+	let output = `\t${titleColor(title)} [${ruleName}]\n`;
 
 	if (result.locations) {
 		result.locations.forEach(location => {


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce command line options to allow packaging specific secrets, all kinds of secrets, and .env files. Update the packaging process to validate these options and handle potential security issues accordingly.

closes https://github.com/microsoft/vscode-vsce/issues/1136
closes https://github.com/microsoft/vscode-vsce/issues/1135