### PR TITLE
Do not scan node modules and improve error messages for secret scanning

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -2128,9 +2128,10 @@ export async function scanFilesForSecrets(files: IFile[], fileExclusion: FileExc
 	}
 
 	const onDiskFiles: ILocalFile[] = files.filter(file => !isInMemoryFile(file)) as ILocalFile[];
+	const onDiskNoneNodeModulesFiles = onDiskFiles.filter(file => !file.localPath.includes('node_modules'));
 	const inMemoryFiles: IInMemoryFile[] = files.filter(file => isInMemoryFile(file)) as IInMemoryFile[];
 
-	const onDiskResult = await lintFiles(onDiskFiles.map(file => file.localPath));
+	const onDiskResult = await lintFiles(onDiskNoneNodeModulesFiles.map(file => file.localPath));
 	const inMemoryResults = await Promise.all(
 		inMemoryFiles.map(file => lintText(typeof file.contents === 'string' ? file.contents : file.contents.toString('utf8'), file.path))
 	);

--- a/src/secretLint.ts
+++ b/src/secretLint.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { Convert, Location, Region, Result, Level } from "./typings/secret-lint-types";
+import { log } from "./util";
 
 interface SecretLintEngineResult {
 	ok: boolean;
@@ -40,7 +41,7 @@ const lintConfig = {
 
 const lintOptions = {
 	configFileJSON: lintConfig,
-	formatter: "@secretlint/secretlint-formatter-sarif", // checkstyle, compact, jslint-xml, junit, pretty-error, stylish, tap, unix, json, mask-result, table
+	formatter: "@secretlint/secretlint-formatter-sarif",
 	color: true,
 	maskSecrets: false
 };
@@ -59,9 +60,16 @@ export async function lintFiles(
 ): Promise<SecretLintResult> {
 	const engine = await getEngine();
 
-	const engineResult = await engine.executeOnFiles({
-		filePathList: filePaths
-	});
+	let engineResult;
+	try {
+		engineResult = await engine.executeOnFiles({
+			filePathList: filePaths
+		});
+	} catch (error) {
+		log.error('Error occurred while scanning secrets (files):', error);
+		process.exit(1);
+	}
+
 	return parseResult(engineResult);
 }
 
@@ -71,10 +79,16 @@ export async function lintText(
 ): Promise<SecretLintResult> {
 	const engine = await getEngine();
 
-	const engineResult = await engine.executeOnContent({
-		content,
-		filePath: fileName
-	});
+	let engineResult;
+	try {
+		engineResult = await engine.executeOnContent({
+			content,
+			filePath: fileName
+		});
+	} catch (error) {
+		log.error('Error occurred while scanning secrets (content):', error);
+		process.exit(1);
+	}
 	return parseResult(engineResult);
 }
 


### PR DESCRIPTION
```Copilot Generated Description:``` Exclude node modules from secret scanning and enhance error handling with clearer messages for scanning errors.

related https://github.com/microsoft/vscode-vsce/issues/1147
related https://github.com/microsoft/vscode-vsce/issues/1150