### PR TITLE
Only scan secrets when .env is ignored and vice versa

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -239,7 +239,7 @@ module.exports = function (argv: string[]): void {
 		.addOption(new Option('--noVerify', 'Allow all proposed APIs (deprecated: use --allow-all-proposed-apis instead)').hideHelp(true))
 		.option('--allow-proposed-apis <apis...>', 'Allow specific proposed APIs')
 		.option('--allow-all-proposed-apis', 'Allow all proposed APIs')
-		.option('--allow-package-secrets <secrets...>', 'Allow packaging specific secrets. The names of the secrets can be found in the error message ([SECRET_NAME]).')
+		.option('--allow-package-secrets <secret_type>', 'Allow packaging a specific type of secret. The type of the secrets can be found in the error message ([SECRET_TYPE]).')
 		.option('--allow-package-all-secrets', 'Allow to package all kinds of secrets')
 		.option('--allow-package-env-file', 'Allow packaging .env files')
 		.option('--ignoreFile <path>', 'Indicate alternative .vscodeignore')

--- a/src/package.ts
+++ b/src/package.ts
@@ -2123,16 +2123,18 @@ enum FileExclusionType {
 }
 
 export async function scanFilesForSecrets(files: IFile[], fileExclusion: FileExclusionType, options: IPackageOptions): Promise<void> {
-	if (options.allowPackageAllSecrets && options.allowPackageEnvFile) {
+	const scanForSecrets = !options.allowPackageAllSecrets;
+	const scanDotEnv = !options.allowPackageEnvFile;
+	if (!scanForSecrets && !scanDotEnv) {
 		return; // No need to scan
 	}
 
 	const onDiskFiles: ILocalFile[] = files.filter(file => !isInMemoryFile(file)) as ILocalFile[];
 	const inMemoryFiles: IInMemoryFile[] = files.filter(file => isInMemoryFile(file)) as IInMemoryFile[];
 
-	const onDiskResult = await lintFiles(onDiskFiles.map(file => file.localPath));
+	const onDiskResult = await lintFiles(onDiskFiles.map(file => file.localPath), scanForSecrets, scanDotEnv);
 	const inMemoryResults = await Promise.all(
-		inMemoryFiles.map(file => lintText(typeof file.contents === 'string' ? file.contents : file.contents.toString('utf8'), file.path))
+		inMemoryFiles.map(file => lintText(typeof file.contents === 'string' ? file.contents : file.contents.toString('utf8'), file.path, scanForSecrets, scanDotEnv))
 	);
 
 	const secretsFound = [...inMemoryResults, onDiskResult].filter(result => !result.ok).flatMap(result => result.results);
@@ -2149,13 +2151,13 @@ export async function scanFilesForSecrets(files: IFile[], fileExclusion: FileExc
 		const secretsFoundRuleNames = Array.from(uniqueSecretIds).map(getRuleNameFromRuleId);
 
 		let errorMessage = `${chalk.bold('Potential security issue detected:')}`;
-		errorMessage += ` Your extension package contains sensitive information that should not be published.`
+		errorMessage += ` Your extension package contains sensitive information that should not be published.`;
 		errorMessage += ` Please remove these secrets before packaging.`;
 		errorMessage += `\n` + noneDotEnvSecretsFound.map(prettyPrintLintResult).join('\n');
 
-		let hintMessage = `\nIn case of a false positives, you can allowlist secrets with `;
+		let hintMessage = `\nIn case of false positives, you can allow specific types of secrets with `;
 		hintMessage += secretsFoundRuleNames.map(name => `--allow-package-secrets ${name}`).join(' ');
-		hintMessage += ` or use --allow-package-all-secrets to skip this check (not recommended).`;
+		hintMessage += ` or use --allow-package-all-secrets to skip this check entirely (not recommended).`;
 
 		util.log.error(errorMessage + chalk.italic(hintMessage));
 		process.exit(1);

--- a/src/secretLint.ts
+++ b/src/secretLint.ts
@@ -11,53 +11,65 @@ interface SecretLintResult {
 	results: Result[];
 }
 
-const lintConfig = {
-	rules: [
-		{
-			id: "@secretlint/secretlint-rule-preset-recommend",
-			rules: [
-				{
-					id: "@secretlint/secretlint-rule-basicauth",
-					allowMessageIds: ["BasicAuth"]
-				},
-				{
-					id: "@secretlint/secretlint-rule-privatekey",
-					options: {
-						allows: [
-							// Allow all keys which do not start and end with the BEGIN/END PRIVATE KEY and has at least 50 characters in between
-							// https://github.com/microsoft/vscode-vsce/issues/1147
-							"/^(?![\\s\\S]*-----BEGIN .*PRIVATE KEY-----[A-Za-z0-9+/=\\r\\n]{50,}-----END .*PRIVATE KEY-----)[\\s\\S]*$/"
-						]
-					}
+const secretsScanningRules = [
+	{
+		id: "@secretlint/secretlint-rule-preset-recommend",
+		rules: [
+			{
+				id: "@secretlint/secretlint-rule-basicauth",
+				allowMessageIds: ["BasicAuth"]
+			},
+			{
+				id: "@secretlint/secretlint-rule-privatekey",
+				options: {
+					allows: [
+						// Allow all keys which do not start and end with the BEGIN/END PRIVATE KEY and has at least 50 characters in between
+						// https://github.com/microsoft/vscode-vsce/issues/1147
+						"/^(?![\\s\\S]*-----BEGIN .*PRIVATE KEY-----[A-Za-z0-9+/=\\r\\n]{50,}-----END .*PRIVATE KEY-----)[\\s\\S]*$/"
+					]
 				}
-			]
-		}, {
-			id: "@secretlint/secretlint-rule-no-dotenv"
-		}
+			}
+		]
+	}
+];
 
-	]
-};
-
-const lintOptions = {
-	configFileJSON: lintConfig,
-	formatter: "@secretlint/secretlint-formatter-sarif", // checkstyle, compact, jslint-xml, junit, pretty-error, stylish, tap, unix, json, mask-result, table
-	color: true,
-	maskSecrets: false
-};
+const dotEnvRules = [
+	{
+		id: "@secretlint/secretlint-rule-no-dotenv"
+	}
+];
 
 // Helper function to dynamically import the createEngine function
-async function getEngine() {
+async function getEngine(scanSecrets: boolean, scanDotEnv: boolean) {
 	// Use a raw dynamic import that will not be transformed
 	// This is necessary because @secretlint/node is an ESM module
 	const secretlintModule = await eval('import("@secretlint/node")');
+
+	const rules = [];
+	if (scanSecrets) {
+		rules.push(...secretsScanningRules);
+	}
+	if (scanDotEnv) {
+		rules.push(...dotEnvRules);
+	}
+
+	const lintOptions = {
+		configFileJSON: { rules: rules },
+		formatter: "@secretlint/secretlint-formatter-sarif", // checkstyle, compact, jslint-xml, junit, pretty-error, stylish, tap, unix, json, mask-result, table
+		color: true,
+		maskSecrets: false
+	};
+
 	const engine = await secretlintModule.createEngine(lintOptions);
 	return engine;
 }
 
 export async function lintFiles(
-	filePaths: string[]
+	filePaths: string[],
+	scanSecrets: boolean,
+	scanDotEnv: boolean
 ): Promise<SecretLintResult> {
-	const engine = await getEngine();
+	const engine = await getEngine(scanSecrets, scanDotEnv);
 
 	const engineResult = await engine.executeOnFiles({
 		filePathList: filePaths
@@ -67,9 +79,11 @@ export async function lintFiles(
 
 export async function lintText(
 	content: string,
-	fileName: string
+	fileName: string,
+	scanSecrets: boolean,
+	scanDotEnv: boolean
 ): Promise<SecretLintResult> {
-	const engine = await getEngine();
+	const engine = await getEngine(scanSecrets, scanDotEnv);
 
 	const engineResult = await engine.executeOnContent({
 		content,


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the scanning logic to only check for secrets when the corresponding options for packaging all secrets and .env files are not enabled. Update related error messages and linting configurations accordingly.