### PR TITLE
Fix npm token scanning false positives

### DIFF
--- a/src/secretLint.ts
+++ b/src/secretLint.ts
@@ -20,14 +20,22 @@ const lintConfig = {
 				{
 					id: "@secretlint/secretlint-rule-basicauth",
 					allowMessageIds: ["BasicAuth"]
-				},
-				{
+				}, {
 					id: "@secretlint/secretlint-rule-privatekey",
 					options: {
 						allows: [
 							// Allow all keys which do not start and end with the BEGIN/END PRIVATE KEY and has at least 50 characters in between
 							// https://github.com/microsoft/vscode-vsce/issues/1147
 							"/^(?![\\s\\S]*-----BEGIN .*PRIVATE KEY-----[A-Za-z0-9+/=\\r\\n]{50,}-----END .*PRIVATE KEY-----)[\\s\\S]*$/"
+						]
+					}
+				}, {
+					id: "@secretlint/secretlint-rule-npm",
+					options: {
+						allows: [
+							// An npm token has the prefix npm_ followed by 36 Base62 characters (30 random + 6-character checksum), totaling 40 characters.
+							// https://github.com/microsoft/vscode-vsce/issues/1153
+							"/^(?!(?:npm_[0-9A-Za-z]{36})$).+$/"
 						]
 					}
 				}

--- a/src/test/fixtures/secrets/noSecret1Ignore
+++ b/src/test/fixtures/secrets/noSecret1Ignore
@@ -1,2 +1,3 @@
 **secret**
+**noSecret**
 !noSecret1.ts

--- a/src/test/fixtures/secrets/noSecret3.ts
+++ b/src/test/fixtures/secrets/noSecret3.ts
@@ -1,0 +1,4 @@
+// https://github.com/microsoft/vscode-vsce/issues/1153
+function npm_i_save_dev_types_Slashjest_or_npm_i_(){}
+function npm_i_save_dev_types_Slash_1_if_it_exists(){}
+function Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_jQuery_Try_npm_i_save_dev_types_Slashjquery_and_then_add_jquery_to_the_types_field_in_your_tsconfig(){}

--- a/src/test/fixtures/secrets/noSecret3Ignore
+++ b/src/test/fixtures/secrets/noSecret3Ignore
@@ -1,3 +1,3 @@
 **secret**
 **noSecret**
-!noSecret2.ts
+!noSecret3.ts

--- a/src/test/fixtures/secrets/secret1Ignore
+++ b/src/test/fixtures/secrets/secret1Ignore
@@ -1,2 +1,3 @@
 **secret**
+**noSecret**
 !secret1.ts

--- a/src/test/fixtures/secrets/secret2.ts
+++ b/src/test/fixtures/secrets/secret2.ts
@@ -1,0 +1,1 @@
+export const k = `npm_Ab3kZy0X9QpLmN4tUvW7aBcDeFgHiJkLmNoPqRsTu`

--- a/src/test/fixtures/secrets/secret2Ignore
+++ b/src/test/fixtures/secrets/secret2Ignore
@@ -1,3 +1,3 @@
 **secret**
 **noSecret**
-!noSecret2.ts
+!secret2.ts


### PR DESCRIPTION
```Copilot Generated Description:``` Enhance the secret linting rules to accurately identify npm tokens and prevent false positives during scanning. Add test cases to validate the new behavior.

closes https://github.com/microsoft/vscode-vsce/issues/1153