### PR TITLE
Sanitize tags to remove special characters

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -297,9 +297,13 @@ function escapeRegExp(value: string) {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
 
+function sanitizeTag(tag: string): string {
+	return tag.replace(/\W/g, '');
+}
+
 function toExtensionTags(extensions: string[]): string[] {
 	return extensions
-		.map(s => s.replace(/\W/g, ''))
+		.map(sanitizeTag)
 		.filter(s => !!s)
 		.map(s => `__ext_${s}`);
 }
@@ -687,7 +691,7 @@ export class TagsProcessor extends BaseProcessor {
 		);
 
 		const languageContributions = ((contributes && contributes['languages']) ?? []).reduce<string[]>(
-			(r, l) => [...r, l.id, ...(l.aliases ?? []), ...toExtensionTags(l.extensions ?? [])],
+			(r, l) => [...r, l.id, ...(l.aliases ?? []).map(sanitizeTag), ...toExtensionTags(l.extensions ?? [])],
 			[]
 		);
 


### PR DESCRIPTION
Introduce a function to sanitize tags by removing non-word characters. Update the processing of language contributions to apply this sanitization to aliases, ensuring that tags conform to the required format.

Fixes microsoft/vscode-vsce#1164