### PR TITLE
Allow dots in tags and update extension tag handling

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -298,12 +298,13 @@ function escapeRegExp(value: string) {
 }
 
 function sanitizeTag(tag: string): string {
-	return tag.replace(/[^\w-]/g, '');
+	return tag.replace(/[^\w.-]/g, '');
 }
 
 function toExtensionTags(extensions: string[]): string[] {
 	return extensions
 		.map(sanitizeTag)
+		.map(s => s.replace('.', ''))
 		.filter(s => !!s)
 		.map(s => `__ext_${s}`);
 }

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1643,7 +1643,7 @@ describe('toVsixManifest', () => {
 				languages: [
 					{
 						id: 'go',
-						aliases: ['golang', 'google-go'],
+						aliases: ['golang', 'google-go', '@sql'],
 					},
 				],
 			},
@@ -1656,6 +1656,7 @@ describe('toVsixManifest', () => {
 				assert.ok(tags.some(tag => tag === 'go'));
 				assert.ok(tags.some(tag => tag === 'golang'));
 				assert.ok(tags.some(tag => tag === 'google-go'));
+				assert.ok(tags.some(tag => tag === 'sql'));
 			});
 	});
 
@@ -1785,7 +1786,7 @@ describe('toVsixManifest', () => {
 				languages: [
 					{
 						id: 'go',
-						extensions: ['.go', '@sql'],
+						extensions: ['.go'],
 					},
 				],
 			},
@@ -1796,7 +1797,6 @@ describe('toVsixManifest', () => {
 			.then(result => {
 				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
 				assert.ok(tags.some(tag => tag === '__ext_go'));
-				assert.ok(tags.some(tag => tag === '__ext_sql'));
 			});
 	});
 

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1785,7 +1785,7 @@ describe('toVsixManifest', () => {
 				languages: [
 					{
 						id: 'go',
-						extensions: ['.go'],
+						extensions: ['.go', '@sql'],
 					},
 				],
 			},
@@ -1796,6 +1796,7 @@ describe('toVsixManifest', () => {
 			.then(result => {
 				const tags = result.PackageManifest.Metadata[0].Tags[0].split(',') as string[];
 				assert.ok(tags.some(tag => tag === '__ext_go'));
+				assert.ok(tags.some(tag => tag === '__ext_sql'));
 			});
 	});
 


### PR DESCRIPTION
```Copilot Generated Description:``` Enable the use of dots in tags while maintaining the previous behavior for extension tags. Add a test to verify the changes.