### PR TITLE
add `commonjs` annotation to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"type": "git",
 		"url": "https://github.com/Microsoft/vsce"
 	},
+	"type": "commonjs",
 	"homepage": "https://code.visualstudio.com",
 	"bugs": "https://github.com/Microsoft/vsce/issues",
 	"keywords": [


### PR DESCRIPTION
I'm working on making this tool compatible with [`deno`](https://deno.com/) and [`bun`](https://bun.sh/) for a personal project. It looks like I'm not the only one who would like to add that support (See: #1108)

Modern JS standards suggest either using a `.cjs` extension or a module `type` declaration on a package to know whether something is a commonjs module or an esm module. See: https://nodejs.org/api/packages.html#packagejson-and-file-extensions

This change adds the missing `"type": "commonjs"` annotation to the package.json file to allow `deno` to run the files correctly.