### PR TITLE
main: expose `--packagedDependencies` to commands other than `ls`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -114,6 +114,12 @@ module.exports = function (argv: string[]): void {
 		.option('--baseImagesUrl <url>', 'Prepend all relative image links in README.md with the specified URL.')
 		.option('--yarn', 'Use yarn instead of npm (default inferred from presence of yarn.lock or .yarnrc)')
 		.option('--no-yarn', 'Use npm instead of yarn (default inferred from absence of yarn.lock or .yarnrc)')
+		.option<string[]>(
+			'--packagedDependencies <path>',
+			'Select packages that should be published only (includes dependencies)',
+			(val, all) => (all ? all.concat(val) : [val]),
+			undefined
+		)
 		.option('--ignoreFile <path>', 'Indicate alternative .vscodeignore')
 		.option('--no-gitHubIssueLinking', 'Disable automatic expansion of GitHub-style issue syntax into links')
 		.option('--no-gitLabIssueLinking', 'Disable automatic expansion of GitLab-style issue syntax into links')
@@ -148,6 +154,7 @@ module.exports = function (argv: string[]): void {
 					baseContentUrl,
 					baseImagesUrl,
 					yarn,
+					packagedDependencies,
 					ignoreFile,
 					gitHubIssueLinking,
 					gitLabIssueLinking,
@@ -181,6 +188,7 @@ module.exports = function (argv: string[]): void {
 						baseContentUrl,
 						baseImagesUrl,
 						useYarn: yarn,
+						dependencyEntryPoints: packagedDependencies,
 						ignoreFile,
 						gitHubIssueLinking,
 						gitLabIssueLinking,
@@ -235,6 +243,13 @@ module.exports = function (argv: string[]): void {
 		.option('--baseImagesUrl <url>', 'Prepend all relative image links in README.md with the specified URL.')
 		.option('--yarn', 'Use yarn instead of npm (default inferred from presence of yarn.lock or .yarnrc)')
 		.option('--no-yarn', 'Use npm instead of yarn (default inferred from absence of yarn.lock or .yarnrc)')
+		.option('--deno', 'Use deno instead of npm (default inferred from presence of deno.lock)')
+		.option<string[]>(
+			'--packagedDependencies <path>',
+			'Select packages that should be published only (includes dependencies)',
+			(val, all) => (all ? all.concat(val) : [val]),
+			undefined
+		)
 		.option('--no-verify', 'Allow all proposed APIs (deprecated: use --allow-all-proposed-apis instead)')
 		.addOption(new Option('--noVerify', 'Allow all proposed APIs (deprecated: use --allow-all-proposed-apis instead)').hideHelp(true))
 		.option('--allow-proposed-apis <apis...>', 'Allow specific proposed APIs')
@@ -275,6 +290,7 @@ module.exports = function (argv: string[]): void {
 					baseContentUrl,
 					baseImagesUrl,
 					yarn,
+					packagedDependencies,
 					verify,
 					noVerify,
 					allowProposedApis,
@@ -315,6 +331,7 @@ module.exports = function (argv: string[]): void {
 						baseContentUrl,
 						baseImagesUrl,
 						useYarn: yarn,
+						dependencyEntryPoints: packagedDependencies,
 						noVerify: noVerify || !verify,
 						allowProposedApis,
 						allowAllProposedApis,


### PR DESCRIPTION
Currently, there's no way to expose `--packagedDependencies` when packaging from the CLI.
The CLI is only capable of querying the list of files with `vsce ls --packageDependencies`

This change adds the same CLI flag from `ls` to `package` and `publish`.

The user-facing benefit of this change is to allow publishing a limited subtree of dependencies from a javascript monorepo. Currently, a vscode extension in a javascript monorepo will publish the entire workspace's unfiltered dependency tree, as it has no way to specify `--packagedDependencies` during `publish` or `package`