### PR TITLE
fix: pack fails in monorepo due to duplicate files

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -1674,7 +1674,7 @@ async function collectAllFiles(
 		)
 	);
 
-	return Promise.all(promises).then(util.flatten);
+	return Promise.all(promises).then(util.flatten).then((files)=> Array.from(new Set(files)));
 }
 
 function getDependenciesOption(options: IPackageOptions): 'npm' | 'yarn' | 'none' | undefined {


### PR DESCRIPTION
When running `vsce pack` or `vsce ls` in a monorepo or workspace setup, duplicate files may appear in the packaged file list leading to pack fail. 

<img width="872" height="279" alt="image" src="https://github.com/user-attachments/assets/3e67d1f9-ec18-4ef0-9899-960a6f5990e7" />

This is because the internal dependency collection uses the output of:

```shell
npm list --production --parseable --depth=99999 --loglevel=error
```

<img width="944" height="275" alt="image" src="https://github.com/user-attachments/assets/2df698b8-d003-417e-b3ad-4259bfe0f4b2" />

However, this command always includes the project root directory as the first line of its output. As a result, when we later glob for files in each dependency directory, the root directory is also globbed, causing all files (including those in subdirectories like node_modules in sub packages) to be collected multiple times.

https://github.com/microsoft/vscode-vsce/blob/294d71b0173bc5f2017a4dac880a0206621a14e6/src/package.ts#L1671-L1675

You can reproduce this at [yuzheng14/valype](https://github.com/yuzheng14/valype) (temporarily it would exist in [feat/vscode-extension branch](https://github.com/yuzheng14/valype/tree/feat/vscode-extension) only).

> Fixes #812 