### PR TITLE
Avoid Node.js DEP0190 warning by using string form for prepublish command

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -1880,7 +1880,8 @@ export async function prepublish(cwd: string, manifest: ManifestPackage, useYarn
 
 	await new Promise<void>((c, e) => {
 		const tool = useYarn ? 'yarn' : 'npm';
-		const child = cp.spawn(tool, ['run', 'vscode:prepublish'], { cwd, shell: true, stdio: 'inherit' });
+		// Use string command to avoid Node.js DEP0190 warning (args + shell: true is deprecated).
+		const child = cp.spawn(`${tool} run vscode:prepublish`, { cwd, shell: true, stdio: 'inherit' });
 		child.on('exit', code => (code === 0 ? c() : e(`${tool} failed with exit code ${code}`)));
 		child.on('error', e);
 	});

--- a/src/package.ts
+++ b/src/package.ts
@@ -1876,12 +1876,14 @@ export async function prepublish(cwd: string, manifest: ManifestPackage, useYarn
 		useYarn = await detectYarn(cwd);
 	}
 
-	console.log(`Executing prepublish script '${useYarn ? 'yarn' : 'npm'} run vscode:prepublish'...`);
+	const tool = useYarn ? 'yarn' : 'npm';
+	const prepublish = `${tool} run vscode:prepublish`;
+
+	console.log(`Executing prepublish script '${prepublish}'...`);
 
 	await new Promise<void>((c, e) => {
-		const tool = useYarn ? 'yarn' : 'npm';
 		// Use string command to avoid Node.js DEP0190 warning (args + shell: true is deprecated).
-		const child = cp.spawn(`${tool} run vscode:prepublish`, { cwd, shell: true, stdio: 'inherit' });
+		const child = cp.spawn(prepublish, { cwd, shell: true, stdio: 'inherit' });
 		child.on('exit', code => (code === 0 ? c() : e(`${tool} failed with exit code ${code}`)));
 		child.on('error', e);
 	});


### PR DESCRIPTION
## What this PR does

* Fixes the Node.js `DEP0190` deprecation warning:

  ```
  [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities...
  ```
* Replaces the deprecated pattern:

  ```ts
  spawn(tool, ['run', 'vscode:prepublish'], { shell: true, ... });
  ```

  with the safe and supported string form:

  ```ts
  spawn(`${tool} run vscode:prepublish`, { shell: true, ... });
  ```

## Why this matters

* Starting with Node.js 20, using `shell: true` with an argument array triggers a warning and is discouraged.
* This is a well-known Node.js issue documented here:
  [https://github.com/nodejs/node/issues/58763](https://github.com/nodejs/node/issues/58763)

## Why this is safe

* The `tool` value is controlled (`npm` or `yarn`), no user input is involved.
* The command is static and cannot be exploited.
* This form fully avoids the `DEP0190` warning in all supported Node.js versions.

## Additional improvements

* Extracts the command string into a `prepublish` variable for reuse in both logging and execution.
* Improves readability without changing behavior.