### PR TITLE
fix: generate language model tag for `languageModelChatProvider` contributions

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -683,7 +683,7 @@ export class TagsProcessor extends BaseProcessor {
 		const remoteMenu = doesContribute('menus', 'statusBar/remoteIndicator') ? ['remote-menu'] : [];
 		const chatParticipants = doesContribute('chatParticipants') ? ['chat-participant'] : [];
 		const languageModelTools = doesContribute('languageModelTools') ? ['tools', 'language-model-tools'] : [];
-		const languageModels = doesContribute('languageModels') ? ['language-models'] : [];
+		const languageModels = doesContribute('languageModelChatProviders') ? ['language-models'] : [];
 		const mcp = doesContribute('modelContextServerCollections') ? ['mcp', 'language-model-tools'] : [];
 
 		const localizationContributions = ((contributes && contributes['localizations']) ?? []).reduce<string[]>(

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -1486,7 +1486,7 @@ describe('toVsixManifest', () => {
 			version: '0.0.1',
 			engines: Object.create(null),
 			contributes: {
-				languageModels: [{ name: 'test', id: 'test' }],
+				languageModelChatProviders: [{ name: 'test', id: 'test' }],
 			},
 		};
 


### PR DESCRIPTION
Autogenerating `language-model` tags doesn't currently work, which seems to be because the contribution was renamed 4 weeks ago: https://github.com/microsoft/vscode/blob/f9618ba2a9749ee72df385329c56208eefdb3ef9/src/vs/workbench/contrib/chat/common/languageModels.ts#L290-L291

cc @benibenj @isidorn