### PR TITLE
Replace keytar with @napi-rs/keyring/keytar

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,8 @@ Read the [**Documentation**](https://code.visualstudio.com/api/working-with-exte
 
 ### Linux
 
-In order to save credentials safely, this project uses [`keytar`](https://www.npmjs.com/package/keytar) which uses `libsecret`, which you may need to install before publishing extensions. Setting the `VSCE_STORE=file` environment variable will revert back to the file credential store. Using the `VSCE_PAT` environment variable will also avoid using `keytar`.
-
-Depending on your distribution, you will need to run the following command:
-
-- Debian/Ubuntu: `sudo apt-get install libsecret-1-dev`
-- Alpine: `apk add libsecret`
-- Red Hat-based: `sudo yum install libsecret-devel`
-- Arch Linux: `sudo pacman -S libsecret`
+In order to save credentials safely, this project uses [`@napi-rs/keyring`](https://www.npmjs.com/package/@napi-rs/keyring
+). Setting the `VSCE_STORE=file` environment variable will revert back to the file credential store. Using the `VSCE_PAT` environment variable will also avoid using `@napi-rs/keyring`.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
 				"node": ">= 20"
 			},
 			"optionalDependencies": {
-				"keytar": "^7.7.0"
+				"@napi-rs/keyring": "^1.2.0"
 			}
 		},
 		"node_modules/@azu/format-text": {
@@ -521,6 +521,226 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@napi-rs/keyring": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+			"integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"optionalDependencies": {
+				"@napi-rs/keyring-darwin-arm64": "1.2.0",
+				"@napi-rs/keyring-darwin-x64": "1.2.0",
+				"@napi-rs/keyring-freebsd-x64": "1.2.0",
+				"@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+				"@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+				"@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+				"@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+				"@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+				"@napi-rs/keyring-linux-x64-musl": "1.2.0",
+				"@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+				"@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+				"@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+			}
+		},
+		"node_modules/@napi-rs/keyring-darwin-arm64": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+			"integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-darwin-x64": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+			"integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-freebsd-x64": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+			"integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+			"integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+			"integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-linux-arm64-musl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+			"integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+			"integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-linux-x64-gnu": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+			"integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-linux-x64-musl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+			"integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+			"integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+			"integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/keyring-win32-x64-msvc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+			"integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -1330,52 +1550,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"optional": true
-		},
-		"node_modules/are-we-there-yet": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-			"integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-			"optional": true,
-			"dependencies": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			}
-		},
-		"node_modules/are-we-there-yet/node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"optional": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/are-we-there-yet/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"optional": true
-		},
-		"node_modules/are-we-there-yet/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"optional": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"node_modules/arg": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1415,26 +1589,6 @@
 			"resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"optional": true
-		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1457,17 +1611,6 @@
 			},
 			"funding": {
 				"url": "https://bevry.me/fund"
-			}
-		},
-		"node_modules/bl": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-			"optional": true,
-			"dependencies": {
-				"buffer": "^5.5.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0"
 			}
 		},
 		"node_modules/boolbase": {
@@ -1507,30 +1650,6 @@
 			"resolved": "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA= sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
-		},
-		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"optional": true,
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
 		},
 		"node_modules/buffer-crc32": {
 			"version": "0.2.13",
@@ -1647,12 +1766,6 @@
 				"fsevents": "~2.3.2"
 			}
 		},
-		"node_modules/chownr": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-			"optional": true
-		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1674,15 +1787,6 @@
 			"integrity": "sha512-5yARKww0dWyWg2/3xZeXgoxjHLwpVqFptj9Zy7qioJ6+/L0ARM184sgMUrQDjxw7ePJWlGhV998mKhzrxT0/Kg==",
 			"engines": {
 				"node": ">=16"
-			}
-		},
-		"node_modules/code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/color-convert": {
@@ -1736,18 +1840,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"node_modules/console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"optional": true
-		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"optional": true
 		},
 		"node_modules/create-require": {
 			"version": "1.1.1",
@@ -1812,30 +1904,6 @@
 				}
 			}
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"optional": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"optional": true,
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
 		"node_modules/define-lazy-prop": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -1850,21 +1918,6 @@
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"optional": true
-		},
-		"node_modules/detect-libc": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.0.tgz",
-			"integrity": "sha512-S55LzUl8HUav8l9E2PBTlC5PAJrHK7tkM+XXFGD+fbsbkTzhCpG6K05LxJcUOEWzMa4v6ptcMZ9s3fOdJDu0Zw==",
-			"optional": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/diff": {
@@ -1974,15 +2027,6 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
-		"node_modules/end-of-stream": {
-			"version": "1.4.4",
-			"resolved": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA= sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"optional": true,
-			"dependencies": {
-				"once": "^1.4.0"
-			}
-		},
 		"node_modules/entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -2073,15 +2117,6 @@
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"engines": {
 				"node": ">=0.8.x"
-			}
-		},
-		"node_modules/expand-template": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-			"optional": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -2230,12 +2265,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-			"optional": true
-		},
 		"node_modules/fs-extra": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -2270,57 +2299,6 @@
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"optional": true,
-			"dependencies": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			}
-		},
-		"node_modules/gauge/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/gauge/node_modules/string-width": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"optional": true,
-			"dependencies": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/gauge/node_modules/strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"optional": true,
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/get-caller-file": {
@@ -2367,12 +2345,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-			"optional": true
 		},
 		"node_modules/glob": {
 			"version": "11.0.0",
@@ -2512,12 +2484,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"optional": true
-		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2591,26 +2557,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"optional": true
-		},
 		"node_modules/ignore": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
@@ -2640,18 +2586,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"optional": true
-		},
-		"node_modules/ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"optional": true
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -2699,18 +2633,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-fullwidth-code-point": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"optional": true,
-			"dependencies": {
-				"number-is-nan": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/is-glob": {
 			"version": "4.0.1",
 			"resolved": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz",
@@ -2752,12 +2674,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"optional": true
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -2910,17 +2826,6 @@
 			"dependencies": {
 				"jwa": "^2.0.0",
 				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/keytar": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/keytar/-/keytar-7.8.0.tgz",
-			"integrity": "sha512-mR+BqtAOIW8j+T5FtLVyckCbvROWQD+4FzPeFMuk5njEZkXLpVPCGF26Y3mTyxMAAL1XCfswR7S6kIf+THSRFA==",
-			"hasInstallScript": true,
-			"optional": true,
-			"dependencies": {
-				"node-addon-api": "^4.3.0",
-				"prebuild-install": "^7.0.1"
 			}
 		},
 		"node_modules/leven": {
@@ -3141,18 +3046,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"optional": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3164,12 +3057,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"optional": true
-		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -3177,12 +3064,6 @@
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
-		},
-		"node_modules/mkdirp-classic": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-			"optional": true
 		},
 		"node_modules/mocha": {
 			"version": "11.1.0",
@@ -3369,30 +3250,6 @@
 			"resolved": "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz",
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
-		"node_modules/napi-build-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-			"optional": true
-		},
-		"node_modules/node-abi": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.8.0.tgz",
-			"integrity": "sha512-tzua9qWWi7iW4I42vUPKM+SfaF0vQSLAm4yO5J83mSwB7GeoWrDKC/K+8YCnYNwqP5duwazbw2X9l4m8SC2cUw==",
-			"optional": true,
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/node-addon-api": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-			"optional": true
-		},
 		"node_modules/node-sarif-builder": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.2.0.tgz",
@@ -3482,18 +3339,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"optional": true,
-			"dependencies": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
 		"node_modules/nth-check": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
@@ -3505,39 +3350,12 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
-		"node_modules/number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/object-inspect": {
 			"version": "1.10.2",
 			"resolved": "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.2.tgz",
 			"integrity": "sha1-tjhaPit8rgter8+Qzd+F0Sh2fzA= sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"optional": true,
-			"dependencies": {
-				"wrappy": "1"
 			}
 		},
 		"node_modules/open": {
@@ -3729,49 +3547,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/prebuild-install": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.1.tgz",
-			"integrity": "sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==",
-			"optional": true,
-			"dependencies": {
-				"detect-libc": "^2.0.0",
-				"expand-template": "^2.0.3",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.3",
-				"mkdirp-classic": "^0.5.3",
-				"napi-build-utils": "^1.0.1",
-				"node-abi": "^3.3.0",
-				"npmlog": "^4.0.1",
-				"pump": "^3.0.0",
-				"rc": "^1.2.7",
-				"simple-get": "^4.0.0",
-				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0"
-			},
-			"bin": {
-				"prebuild-install": "bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"optional": true
-		},
-		"node_modules/pump": {
-			"version": "3.0.0",
-			"resolved": "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ= sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"optional": true,
-			"dependencies": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
 		"node_modules/punycode": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -3834,21 +3609,6 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
-		"node_modules/rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"optional": true,
-			"dependencies": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"bin": {
-				"rc": "cli.js"
-			}
-		},
 		"node_modules/rc-config-loader": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
@@ -3901,20 +3661,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"optional": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/readdirp": {
@@ -4067,12 +3813,6 @@
 				"randombytes": "^2.1.0"
 			}
 		},
-		"node_modules/set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"optional": true
-		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4103,57 +3843,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/signal-exit": {
-			"version": "3.0.3",
-			"resolved": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw= sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-			"optional": true
-		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"optional": true
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"optional": true,
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
 			}
 		},
 		"node_modules/slash": {
@@ -4258,15 +3947,6 @@
 				"npm": ">=6"
 			}
 		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"optional": true,
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"node_modules/string-argv": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -4340,15 +4020,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/structured-source": {
@@ -4436,34 +4107,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"license": "MIT"
-		},
-		"node_modules/tar-fs": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-			"integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-			"optional": true,
-			"dependencies": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			}
-		},
-		"node_modules/tar-stream": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-			"optional": true,
-			"dependencies": {
-				"bl": "^4.0.3",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/terminal-link": {
 			"version": "4.0.0",
@@ -4586,18 +4229,6 @@
 				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
 			}
 		},
-		"node_modules/tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"optional": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/type-fest": {
 			"version": "4.41.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -4679,12 +4310,6 @@
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
 			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
 		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"optional": true
-		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -4744,15 +4369,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/wide-align": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-			"optional": true,
-			"dependencies": {
-				"string-width": "^1.0.2 || 2 || 3 || 4"
-			}
-		},
 		"node_modules/workerpool": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
@@ -4794,12 +4410,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"optional": true
 		},
 		"node_modules/xml2js": {
 			"version": "0.5.0",
@@ -5337,6 +4947,98 @@
 					}
 				}
 			}
+		},
+		"@napi-rs/keyring": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+			"integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+			"optional": true,
+			"requires": {
+				"@napi-rs/keyring-darwin-arm64": "1.2.0",
+				"@napi-rs/keyring-darwin-x64": "1.2.0",
+				"@napi-rs/keyring-freebsd-x64": "1.2.0",
+				"@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+				"@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+				"@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+				"@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+				"@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+				"@napi-rs/keyring-linux-x64-musl": "1.2.0",
+				"@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+				"@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+				"@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+			}
+		},
+		"@napi-rs/keyring-darwin-arm64": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+			"integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+			"optional": true
+		},
+		"@napi-rs/keyring-darwin-x64": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+			"integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+			"optional": true
+		},
+		"@napi-rs/keyring-freebsd-x64": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+			"integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+			"optional": true
+		},
+		"@napi-rs/keyring-linux-arm-gnueabihf": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+			"integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+			"optional": true
+		},
+		"@napi-rs/keyring-linux-arm64-gnu": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+			"integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+			"optional": true
+		},
+		"@napi-rs/keyring-linux-arm64-musl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+			"integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+			"optional": true
+		},
+		"@napi-rs/keyring-linux-riscv64-gnu": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+			"integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+			"optional": true
+		},
+		"@napi-rs/keyring-linux-x64-gnu": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+			"integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+			"optional": true
+		},
+		"@napi-rs/keyring-linux-x64-musl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+			"integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+			"optional": true
+		},
+		"@napi-rs/keyring-win32-arm64-msvc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+			"integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+			"optional": true
+		},
+		"@napi-rs/keyring-win32-ia32-msvc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+			"integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+			"optional": true
+		},
+		"@napi-rs/keyring-win32-x64-msvc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+			"integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+			"optional": true
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -5937,54 +5639,6 @@
 				"picomatch": "^2.0.4"
 			}
 		},
-		"aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"optional": true
-		},
-		"are-we-there-yet": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-			"integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-			"optional": true,
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"optional": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"optional": true
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"optional": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
-		},
 		"arg": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -6020,12 +5674,6 @@
 			"resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"optional": true
-		},
 		"binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6038,17 +5686,6 @@
 			"integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
 			"requires": {
 				"editions": "^6.21.0"
-			}
-		},
-		"bl": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-			"optional": true,
-			"requires": {
-				"buffer": "^5.5.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0"
 			}
 		},
 		"boolbase": {
@@ -6083,16 +5720,6 @@
 			"resolved": "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA= sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
-		},
-		"buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"optional": true,
-			"requires": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
@@ -6173,12 +5800,6 @@
 				"readdirp": "~3.6.0"
 			}
 		},
-		"chownr": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-			"optional": true
-		},
 		"cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -6194,12 +5815,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.1.2.tgz",
 			"integrity": "sha512-5yARKww0dWyWg2/3xZeXgoxjHLwpVqFptj9Zy7qioJ6+/L0ARM184sgMUrQDjxw7ePJWlGhV998mKhzrxT0/Kg=="
-		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"optional": true
 		},
 		"color-convert": {
 			"version": "2.0.1",
@@ -6237,18 +5852,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"optional": true
-		},
-		"core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"optional": true
 		},
 		"create-require": {
 			"version": "1.1.1",
@@ -6291,21 +5894,6 @@
 				"ms": "^2.1.3"
 			}
 		},
-		"decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"optional": true,
-			"requires": {
-				"mimic-response": "^3.1.0"
-			}
-		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"optional": true
-		},
 		"define-lazy-prop": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -6315,18 +5903,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"optional": true
-		},
-		"detect-libc": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.0.tgz",
-			"integrity": "sha512-S55LzUl8HUav8l9E2PBTlC5PAJrHK7tkM+XXFGD+fbsbkTzhCpG6K05LxJcUOEWzMa4v6ptcMZ9s3fOdJDu0Zw==",
-			"optional": true
 		},
 		"diff": {
 			"version": "5.2.0",
@@ -6403,15 +5979,6 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
-		"end-of-stream": {
-			"version": "1.4.4",
-			"resolved": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA= sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"optional": true,
-			"requires": {
-				"once": "^1.4.0"
-			}
-		},
 		"entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -6466,12 +6033,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-		},
-		"expand-template": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-			"optional": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -6577,12 +6138,6 @@
 				"mime-types": "^2.1.12"
 			}
 		},
-		"fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-			"optional": true
-		},
 		"fs-extra": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -6605,50 +6160,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"optional": true,
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"optional": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -6681,12 +6192,6 @@
 				"dunder-proto": "^1.0.1",
 				"es-object-atoms": "^1.0.0"
 			}
-		},
-		"github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-			"optional": true
 		},
 		"glob": {
 			"version": "11.0.0",
@@ -6777,12 +6282,6 @@
 				"has-symbols": "^1.0.3"
 			}
 		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"optional": true
-		},
 		"hasown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -6834,12 +6333,6 @@
 				"debug": "4"
 			}
 		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"optional": true
-		},
 		"ignore": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
@@ -6855,18 +6348,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
 			"integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg=="
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"optional": true
-		},
-		"ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"optional": true
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
@@ -6896,15 +6377,6 @@
 			"resolved": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
-		"is-fullwidth-code-point": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"optional": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
-		},
 		"is-glob": {
 			"version": "4.0.1",
 			"resolved": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz",
@@ -6931,12 +6403,6 @@
 			"requires": {
 				"is-docker": "^2.0.0"
 			}
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"optional": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -7061,16 +6527,6 @@
 			"requires": {
 				"jwa": "^2.0.0",
 				"safe-buffer": "^5.0.1"
-			}
-		},
-		"keytar": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/keytar/-/keytar-7.8.0.tgz",
-			"integrity": "sha512-mR+BqtAOIW8j+T5FtLVyckCbvROWQD+4FzPeFMuk5njEZkXLpVPCGF26Y3mTyxMAAL1XCfswR7S6kIf+THSRFA==",
-			"optional": true,
-			"requires": {
-				"node-addon-api": "^4.3.0",
-				"prebuild-install": "^7.0.1"
 			}
 		},
 		"leven": {
@@ -7238,12 +6694,6 @@
 				"mime-db": "1.52.0"
 			}
 		},
-		"mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"optional": true
-		},
 		"minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -7252,22 +6702,10 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
-		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"optional": true
-		},
 		"minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
 			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
-		},
-		"mkdirp-classic": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-			"optional": true
 		},
 		"mocha": {
 			"version": "11.1.0",
@@ -7399,27 +6837,6 @@
 			"resolved": "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz",
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
-		"napi-build-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-			"optional": true
-		},
-		"node-abi": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.8.0.tgz",
-			"integrity": "sha512-tzua9qWWi7iW4I42vUPKM+SfaF0vQSLAm4yO5J83mSwB7GeoWrDKC/K+8YCnYNwqP5duwazbw2X9l4m8SC2cUw==",
-			"optional": true,
-			"requires": {
-				"semver": "^7.3.5"
-			}
-		},
-		"node-addon-api": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-			"optional": true
-		},
 		"node-sarif-builder": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.2.0.tgz",
@@ -7486,18 +6903,6 @@
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"optional": true,
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
 		"nth-check": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
@@ -7506,31 +6911,10 @@
 				"boolbase": "^1.0.0"
 			}
 		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"optional": true
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"optional": true
-		},
 		"object-inspect": {
 			"version": "1.10.2",
 			"resolved": "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.2.tgz",
 			"integrity": "sha1-tjhaPit8rgter8+Qzd+F0Sh2fzA= sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"optional": true,
-			"requires": {
-				"wrappy": "1"
-			}
 		},
 		"open": {
 			"version": "8.4.2",
@@ -7662,43 +7046,6 @@
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
 			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
 		},
-		"prebuild-install": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.1.tgz",
-			"integrity": "sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==",
-			"optional": true,
-			"requires": {
-				"detect-libc": "^2.0.0",
-				"expand-template": "^2.0.3",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.3",
-				"mkdirp-classic": "^0.5.3",
-				"napi-build-utils": "^1.0.1",
-				"node-abi": "^3.3.0",
-				"npmlog": "^4.0.1",
-				"pump": "^3.0.0",
-				"rc": "^1.2.7",
-				"simple-get": "^4.0.0",
-				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0"
-			}
-		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"optional": true
-		},
-		"pump": {
-			"version": "3.0.0",
-			"resolved": "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ= sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"optional": true,
-			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
 		"punycode": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -7730,18 +7077,6 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
-			}
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"optional": true,
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
 			}
 		},
 		"rc-config-loader": {
@@ -7780,17 +7115,6 @@
 					"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
 					"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="
 				}
-			}
-		},
-		"readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"optional": true,
-			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
 			}
 		},
 		"readdirp": {
@@ -7878,12 +7202,6 @@
 				"randombytes": "^2.1.0"
 			}
 		},
-		"set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"optional": true
-		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7905,29 +7223,6 @@
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
 				"object-inspect": "^1.9.0"
-			}
-		},
-		"signal-exit": {
-			"version": "3.0.3",
-			"resolved": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw= sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-			"optional": true
-		},
-		"simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"optional": true
-		},
-		"simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"optional": true,
-			"requires": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
 			}
 		},
 		"slash": {
@@ -8005,15 +7300,6 @@
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
 			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
 		},
-		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"optional": true,
-			"requires": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"string-argv": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -8069,12 +7355,6 @@
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
-		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"optional": true
 		},
 		"structured-source": {
 			"version": "4.0.0",
@@ -8135,31 +7415,6 @@
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 				}
-			}
-		},
-		"tar-fs": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-			"integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-			"optional": true,
-			"requires": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			}
-		},
-		"tar-stream": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-			"optional": true,
-			"requires": {
-				"bl": "^4.0.3",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
 			}
 		},
 		"terminal-link": {
@@ -8236,15 +7491,6 @@
 			"resolved": "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz",
 			"integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw= sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
 		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"optional": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"type-fest": {
 			"version": "4.41.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -8301,12 +7547,6 @@
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
 			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
 		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"optional": true
-		},
 		"uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -8346,15 +7586,6 @@
 				"isexe": "^2.0.0"
 			}
 		},
-		"wide-align": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-			"optional": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2 || 3 || 4"
-			}
-		},
 		"workerpool": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
@@ -8381,12 +7612,6 @@
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0"
 			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"optional": true
 		},
 		"xml2js": {
 			"version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"typescript": "^4.3.2"
 	},
 	"optionalDependencies": {
-		"keytar": "^7.7.0"
+		"@napi-rs/keyring": "^1.2.0"
 	},
 	"mocha": {
 		"require": [

--- a/src/store.ts
+++ b/src/store.ts
@@ -75,7 +75,7 @@ export class FileStore implements IStore {
 
 export class KeytarStore implements IStore {
 	static async open(serviceName = 'vscode-vsce'): Promise<KeytarStore> {
-		const keytar = await import('keytar');
+		const keytar = await import('@napi-rs/keyring/keytar');
 		const creds = await keytar.findCredentials(serviceName);
 
 		return new KeytarStore(
@@ -90,7 +90,7 @@ export class KeytarStore implements IStore {
 	}
 
 	private constructor(
-		private readonly keytar: typeof import('keytar'),
+		private readonly keytar: typeof import('@napi-rs/keyring/keytar'),
 		private readonly serviceName: string,
 		private publishers: IPublisher[]
 	) { }


### PR DESCRIPTION
[@napi-rs/keyring](https://github.com/Brooooooklyn/keyring-node) exposes an [entry point](https://github.com/Brooooooklyn/keyring-node/blob/main/keytar.js) that is API compatible with `keytar`.

`@napi-rs/keyring` is preferable to `keytar` because it uses NAPI so prebuilt binaries work for any Node.js version. This plus the lack of `libsecret` dependencies makes this package much easier to install.

