### PR TITLE
Fix Options types by making them writable

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -83,15 +83,15 @@ export interface IPackageOptions {
 	 *
 	 * Defaults to `NAME-VERSION.vsix`.
 	 */
-	readonly packagePath?: string;
-	readonly version?: string;
+	packagePath?: string;
+	version?: string;
 
 	/**
 	 * Optional target the extension should run on.
 	 *
 	 * https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions
 	 */
-	readonly target?: string;
+	target?: string;
 
 	/**
 	 * Ignore all files inside folders named as other targets. Only relevant when
@@ -101,74 +101,74 @@ export interface IPackageOptions {
 	 *
 	 * @default false
 	 */
-	readonly ignoreOtherTargetFolders?: boolean;
+	ignoreOtherTargetFolders?: boolean;
 
 	/**
 	 * Recurse into symlinked directories instead of treating them as files.
 	 */
-	readonly followSymlinks?: boolean;
+	followSymlinks?: boolean;
 
-	readonly commitMessage?: string;
-	readonly gitTagVersion?: boolean;
-	readonly updatePackageJson?: boolean;
+	commitMessage?: string;
+	gitTagVersion?: boolean;
+	updatePackageJson?: boolean;
 
 	/**
 	 * The location of the extension in the file system.
 	 *
 	 * Defaults to `process.cwd()`.
 	 */
-	readonly cwd?: string;
+	cwd?: string;
 
-	readonly readmePath?: string;
-	readonly changelogPath?: string;
+	readmePath?: string;
+	changelogPath?: string;
 
 	/**
 	 * GitHub branch used to publish the package. Used to automatically infer
 	 * the base content and images URI.
 	 */
-	readonly githubBranch?: string;
+	githubBranch?: string;
 
 	/**
 	 * GitLab branch used to publish the package. Used to automatically infer
 	 * the base content and images URI.
 	 */
-	readonly gitlabBranch?: string;
+	gitlabBranch?: string;
 
-	readonly rewriteRelativeLinks?: boolean;
+	rewriteRelativeLinks?: boolean;
 	/**
 	 * The base URL for links detected in Markdown files.
 	 */
-	readonly baseContentUrl?: string;
+	baseContentUrl?: string;
 
 	/**
 	 * The base URL for images detected in Markdown files.
 	 */
-	readonly baseImagesUrl?: string;
+	baseImagesUrl?: string;
 
 	/**
 	 * Should use Yarn instead of NPM.
 	 */
-	readonly useYarn?: boolean;
-	readonly dependencyEntryPoints?: string[];
-	readonly ignoreFile?: string;
-	readonly gitHubIssueLinking?: boolean;
-	readonly gitLabIssueLinking?: boolean;
-	readonly dependencies?: boolean;
+	useYarn?: boolean;
+	dependencyEntryPoints?: string[];
+	ignoreFile?: string;
+	gitHubIssueLinking?: boolean;
+	gitLabIssueLinking?: boolean;
+	dependencies?: boolean;
 
 	/**
 	 * Mark this package as a pre-release
 	 */
-	readonly preRelease?: boolean;
-	readonly allowStarActivation?: boolean;
-	readonly allowMissingRepository?: boolean;
-	readonly allowUnusedFilesPattern?: boolean;
-	readonly allowPackageSecrets?: string[];
-	readonly allowPackageAllSecrets?: boolean;
-	readonly allowPackageEnvFile?: boolean;
+	preRelease?: boolean;
+	allowStarActivation?: boolean;
+	allowMissingRepository?: boolean;
+	allowUnusedFilesPattern?: boolean;
+	allowPackageSecrets?: string[];
+	allowPackageAllSecrets?: boolean;
+	allowPackageEnvFile?: boolean;
 
-	readonly skipLicense?: boolean;
+	skipLicense?: boolean;
 
-	readonly signTool?: string;
+	signTool?: string;
 }
 
 export interface IProcessor {
@@ -370,11 +370,11 @@ function isHostTrusted(url: url.URL): boolean {
 }
 
 export interface IVersionBumpOptions {
-	readonly cwd?: string;
-	readonly version?: string;
-	readonly commitMessage?: string;
-	readonly gitTagVersion?: boolean;
-	readonly updatePackageJson?: boolean;
+	cwd?: string;
+	version?: string;
+	commitMessage?: string;
+	gitTagVersion?: boolean;
+	updatePackageJson?: boolean;
 }
 
 export async function versionBump(options: IVersionBumpOptions): Promise<void> {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -22,73 +22,73 @@ const tmpName = promisify(tmp.tmpName);
  * @public
  */
 export interface IPublishOptions {
-	readonly packagePath?: string[];
-	readonly version?: string;
-	readonly targets?: string[];
-	readonly ignoreOtherTargetFolders?: boolean;
-	readonly commitMessage?: string;
-	readonly gitTagVersion?: boolean;
-	readonly updatePackageJson?: boolean;
+	packagePath?: string[];
+	version?: string;
+	targets?: string[];
+	ignoreOtherTargetFolders?: boolean;
+	commitMessage?: string;
+	gitTagVersion?: boolean;
+	updatePackageJson?: boolean;
 
 	/**
 	 * The location of the extension in the file system.
 	 *
 	 * Defaults to `process.cwd()`.
 	 */
-	readonly cwd?: string;
-	readonly readmePath?: string;
-	readonly changelogPath?: string;
-	readonly githubBranch?: string;
-	readonly gitlabBranch?: string;
+	cwd?: string;
+	readmePath?: string;
+	changelogPath?: string;
+	githubBranch?: string;
+	gitlabBranch?: string;
 
 	/**
 	 * The base URL for links detected in Markdown files.
 	 */
-	readonly baseContentUrl?: string;
+	baseContentUrl?: string;
 
 	/**
 	 * The base URL for images detected in Markdown files.
 	 */
-	readonly baseImagesUrl?: string;
+	baseImagesUrl?: string;
 
 	/**
 	 * Should use Yarn instead of NPM.
 	 */
-	readonly useYarn?: boolean;
-	readonly dependencyEntryPoints?: string[];
-	readonly ignoreFile?: string;
+	useYarn?: boolean;
+	dependencyEntryPoints?: string[];
+	ignoreFile?: string;
 
 	/**
 	 * Recurse into symlinked directories instead of treating them as files
 	 */
-	readonly followSymlinks?: boolean;
+	followSymlinks?: boolean;
 
 	/**
 	 * The Personal Access Token to use.
 	 *
 	 * Defaults to the stored one.
 	 */
-	readonly pat?: string;
-	readonly azureCredential?: boolean;
-	readonly allowProposedApi?: boolean;
-	readonly noVerify?: boolean;
-	readonly allowProposedApis?: string[];
-	readonly allowAllProposedApis?: boolean;
-	readonly allowPackageSecrets?: string[];
-	readonly allowPackageAllSecrets?: boolean;
-	readonly allowPackageEnvFile?: boolean;
-	readonly dependencies?: boolean;
-	readonly preRelease?: boolean;
-	readonly allowStarActivation?: boolean;
-	readonly allowMissingRepository?: boolean;
-	readonly allowUnusedFilesPattern?: boolean;
-	readonly skipDuplicate?: boolean;
-	readonly skipLicense?: boolean;
+	pat?: string;
+	azureCredential?: boolean;
+	allowProposedApi?: boolean;
+	noVerify?: boolean;
+	allowProposedApis?: string[];
+	allowAllProposedApis?: boolean;
+	allowPackageSecrets?: string[];
+	allowPackageAllSecrets?: boolean;
+	allowPackageEnvFile?: boolean;
+	dependencies?: boolean;
+	preRelease?: boolean;
+	allowStarActivation?: boolean;
+	allowMissingRepository?: boolean;
+	allowUnusedFilesPattern?: boolean;
+	skipDuplicate?: boolean;
+	skipLicense?: boolean;
 
-	readonly sigzipPath?: string[];
-	readonly manifestPath?: string[];
-	readonly signaturePath?: string[];
-	readonly signTool?: string;
+	sigzipPath?: string[];
+	manifestPath?: string[];
+	signaturePath?: string[];
+	signTool?: string;
 }
 
 export async function publish(options: IPublishOptions = {}): Promise<any> {


### PR DESCRIPTION
I tried integrating the API in semantic-release-vsce but found that the Options interfaces are too restrictive.

They don't allow this like:

```ts
import { createVSIX, IPackageOptions } from './src/api';

const options: IPackageOptions = {}

if (process.env.SOMETHING === 'false') {
  options.gitTagVersion = true;
}

await createVSIX(options);
```

Which fails with:

```
Cannot assign to gitTagVersion because it is a read-only property.
```

So, after thinking about it, I believe the best solution is to remove the `readonly` modifier from all properties of Options interfaces. I don't think they serve any purpose, except making the API harder to use in real-world scenarios.
