### PR TITLE
Expose `verifyPat` to API

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import { publish as _publish, IPublishOptions, unpublish as _unpublish, IUnpublishOptions } from './publish';
 import { packageCommand, listFiles as _listFiles, IPackageOptions } from './package';
+import { verifyPat as _verifyPat, IVerifyPatOptions } from './store';
 
 /**
  * @deprecated prefer IPackageOptions instead
@@ -119,4 +120,14 @@ export type IUnpublishVSIXOptions = IPublishOptions & Pick<IUnpublishOptions, 'i
  */
 export function unpublishVSIX(options: IUnpublishVSIXOptions = {}): Promise<any> {
 	return _unpublish({ force: true, ...options });
+}
+
+export type { IVerifyPatOptions } from './store';
+
+/**
+ * Verifies a Personal Access Token (PAT) for a publisher.
+ * @public
+ */
+export function verifyPat(options: IVerifyPatOptions = {}): Promise<void> {
+	return _verifyPat(options);
 }


### PR DESCRIPTION
Also as part of adoption in semantic-release-vsce, I noticed this API which I need was not exposed.

In case some outsider reads this PR, note that these APIs normally do not honor the environment variables like the CLI does. I.e. `VSCE_PAT` will not be honored by `verifyPat()` like `vsce verify-pat` does.