### PR TITLE
Expose package targets to API

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -56,7 +56,7 @@ export interface IListFilesOptions {
 	ignoreFile?: string;
 }
 
-export type { IPackageOptions } from './package';
+export type { IPackageOptions, Targets } from './package';
 
 /**
  * Creates a VSIX from the extension in the current working directory.


### PR DESCRIPTION
Example of use:

https://github.com/felipecrs/semantic-release-vsce/blob/cd8398f2601e206ef5a69fa08e15c3b8872dcd0d/lib/verify-target.js#L20-L31