### PR TITLE
fix ls not respecting vsce options in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can configure the behavior of `vsce` by using CLI flags (run `vsce --help` t
 $ npx @vscode/vsce publish --baseImagesUrl https://my.custom/base/images/url
 ```
 
-Or you can also set them in the `package.json`, so that you avoid having to retype the common options again. Example:
+You can define the options for `publish` and `package` the `package.json` under the `vsce` property, so that you avoid having to retype the common options again. Example:
 
 ```jsonc
 // package.json

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,3 +1,6 @@
+import type { IPackageOptions } from "./package";
+import type { IPublishOptions } from "./publish";
+
 export interface Person {
 	name: string;
 	url?: string;
@@ -110,7 +113,7 @@ export interface ManifestPackage {
 	files?: string[];
 
 	// vsce
-	vsce?: any;
+	vsce?: Partial<IPackageOptions & IPublishOptions>;
 
 	// not supported (npm)
 	// bin

--- a/src/package.ts
+++ b/src/package.ts
@@ -2040,6 +2040,7 @@ interface ILSOptions {
 export async function ls(options: ILSOptions = {}): Promise<void> {
 	const cwd = process.cwd();
 	const manifest = await readManifest(cwd);
+	util.patchOptionsWithManifest(options, manifest);
 
 	const files = await listFiles({ ...options, cwd, manifest });
 


### PR DESCRIPTION
Fixes #1213 (the `ls` part, not the )

changes:
- update readme to be more accurate
- add proper types instead of `any`
- add the `patchOptionsWithManifest` call needed to make `ls` behave correctly

As it was very unclear what `patchOptionsWithManifest` did, so I scanned the source code to see where it is used and how. I found that only the `publish` and `package` (`ls` as a sub command of `package`) use the `patchOptionsWithManifest` function. Therefore I defined the types to reflect that. It is a bit ugly, because typescript does not like it when you are dynamically patching objects, especially with `readonly` properties, but I think its more accurate this way. I had to use 1 instance of `any` because typescript refuses to believe the properties were assignable, but nothing is changed in runtime semantics as `any` was used before the change.

I tried to add a test, but found there is no existing test (suite) for including options as part of the `package.json`, so was unsure where to add it. The related tests in `package.test.ts` focuss on testing the implementations and bypasses reading the options from the manifest file.

I tested it with:
```console
# to build the local vsce binary
> npm run watch:build

# cwd: src/test/fixtures/devDependencies without `vsce` property in package.json
> node ../../../../vsce ls --tree
root-test-package-1.0.0.vsix
├─ package.json [0.2 KB]
└─ node_modules/
   ├─ real/
   │  ├─ dependency.js
   │  ├─ package.json [0.12 KB]
   │  └─ node_modules/
   │     └─ real_sub/
   │        ├─ dependency.js
   │        └─ package.json [0.05 KB]
   ├─ real2/
   │  ├─ dependency.js
   │  └─ package.json [0.2 KB]
   └─ real_sub/
      ├─ dependency.js
      └─ package.json [0.05 KB]


# cwd: src/test/fixtures/devDependencies with `{ vsce: { dependencies: true } }` in package.json
> node ../../../../vsce ls --tree
root-test-package-1.0.0.vsix
└─ package.json [0.24 KB]

The file package.json is large (0.24 KB)
```
