### PR TITLE
✨ Quality: Include .d.ts files in published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,6 @@
 build/
 src/
 out/test/
-out/**/*.d.ts
 .dockerignore
 .gitignore
 Dockerfile


### PR DESCRIPTION
## Problem

The .npmignore file is currently excluding .d.ts TypeScript declaration files from the published npm package. This prevents library consumers from getting proper TypeScript type definitions when using vsce as a library. We need to modify the ignore patterns to explicitly include .d.ts files while still excluding other unnecessary files.

**Severity**: `high`
**File**: `.npmignore`

## Solution

Remove or modify any pattern that excludes *.d.ts files. Ensure that the dist/ directory (which contains the bundled vsce.d.ts from api-extractor) and out/ directory (which contains individual .d.ts files from TypeScript compilation) are included. Add an explicit include pattern like `!*.d.ts` or `!**/*.d.ts` if there's a broader exclusion pattern, or remove .d.ts from any exclusion patterns.

## Changes

- `.npmignore` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #941