### PR TITLE
Add --marketplace-url global CLI flag

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { show } from './show';
 import { search } from './search';
 import { listPublishers, deletePublisher, loginPublisher, logoutPublisher, verifyPat } from './store';
 import { getLatestVersion } from './npm';
-import { CancellationToken, log } from './util';
+import { CancellationToken, log, setMarketplaceUrl } from './util';
 import * as semver from 'semver';
 import { isatty } from 'tty';
 
@@ -63,6 +63,18 @@ module.exports = function (argv: string[]): void {
 	const program = new Command();
 
 	program.version(pkg.version).usage('<command>');
+
+	program.option(
+		'--marketplace-url <url>',
+		'Marketplace endpoint URL (defaults to VSCE_MARKETPLACE_URL environment variable or https://marketplace.visualstudio.com)'
+	);
+
+	program.hook('preAction', (thisCommand) => {
+		const opts = thisCommand.opts();
+		if (opts.marketplaceUrl) {
+			setMarketplaceUrl(opts.marketplaceUrl);
+		}
+	});
 
 	program
 		.command('ls')

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,7 +18,11 @@ export function read(prompt: string, options: _read.Options = {}): Promise<strin
 	return __read({ prompt, ...options });
 }
 
-const marketplaceUrl = process.env['VSCE_MARKETPLACE_URL'] || 'https://marketplace.visualstudio.com';
+let marketplaceUrl = process.env['VSCE_MARKETPLACE_URL'] || 'https://marketplace.visualstudio.com';
+
+export function setMarketplaceUrl(url: string): void {
+	marketplaceUrl = url;
+}
 
 export function getPublishedUrl(extension: string): string {
 	return `${marketplaceUrl}/items?itemName=${extension}`;


### PR DESCRIPTION
## Summary

Add a global `--marketplace-url <url>` option that overrides the target marketplace endpoint for all commands (publish, unpublish, show, search, etc.). This enables publishing extensions to private or alternative marketplace instances without relying solely on the `VSCE_MARKETPLACE_URL` environment variable.

## Motivation

Enterprise environments need the ability to publish VS extensions to private marketplace instances (e.g., for internal extension distribution, testing, or compliance gating). Currently the only way to override the endpoint is via the `VSCE_MARKETPLACE_URL` environment variable, which is less discoverable and harder to use in CI/CD pipelines where multiple targets may be needed.

A CLI flag makes the override explicit, composable, and documented.

## Changes

- **`src/util.ts`**: Changed `marketplaceUrl` from `const` to `let`, added `setMarketplaceUrl()` export
- **`src/main.ts`**: Added `--marketplace-url <url>` as a global Commander option with a `preAction` hook

## Precedence

`--marketplace-url` flag > `VSCE_MARKETPLACE_URL` env var > default (`marketplace.visualstudio.com`)

## Usage

\\\ash
vsce publish --marketplace-url https://private.marketplace.example.com
vsce show my-extension --marketplace-url https://private.marketplace.example.com
\\\

---
*This PR was assisted by GitHub Copilot using Claude Opus 4.6*