### PR TITLE
fix: build regressions in 3.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '20.x'
       
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
 				"@types/mime": "^1",
 				"@types/minimatch": "^3.0.3",
 				"@types/mocha": "^7.0.2",
-				"@types/node": "^22.19.17",
+				"@types/node": "^20.0.0",
 				"@types/read": "^0.0.28",
 				"@types/semver": "^6.0.0",
 				"@types/tmp": "^0.2.2",
@@ -65,7 +65,7 @@
 				"typescript": "^4.3.2"
 			},
 			"engines": {
-				"node": ">= 22"
+				"node": ">= 20"
 			},
 			"optionalDependencies": {
 				"keytar": "^7.7.0"
@@ -1043,9 +1043,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "22.19.17",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-			"integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+			"version": "20.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4058,16 +4058,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/serialize-javascript": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
 		"node_modules/set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -5716,9 +5706,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "22.19.17",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-			"integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+			"version": "20.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
 			"dev": true,
 			"requires": {
 				"undici-types": "~6.21.0"
@@ -7755,12 +7745,6 @@
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
-		},
-		"serialize-javascript": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
-			"dev": true
 		},
 		"set-blocking": {
 			"version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
 				"typescript": "^4.3.2"
 			},
 			"engines": {
-				"node": ">= 20"
+				"node": ">= 22"
 			},
 			"optionalDependencies": {
 				"keytar": "^7.7.0"
@@ -3817,16 +3817,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/rc": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -4069,13 +4059,13 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/set-blocking": {
@@ -7234,7 +7224,7 @@
 				"minimatch": "^9.0.5",
 				"ms": "^2.1.3",
 				"picocolors": "^1.1.1",
-				"serialize-javascript": "^6.0.2",
+				"serialize-javascript": "7.x",
 				"strip-json-comments": "^3.1.1",
 				"supports-color": "^8.1.1",
 				"workerpool": "^9.2.0",
@@ -7627,15 +7617,6 @@
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
 		},
-		"randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"rc": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -7776,13 +7757,10 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-			"dev": true,
-			"requires": {
-				"randombytes": "^2.1.0"
-			}
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+			"dev": true
 		},
 		"set-blocking": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -100,5 +100,8 @@
 		],
 		"watch-files": "src/**",
 		"spec": "src/test/**/*.ts"
+	},
+	"overrides": {
+		"serialize-javascript": "^6.0.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"watch:test": "npm run test -- --watch"
 	},
 	"engines": {
-		"node": ">= 22"
+		"node": ">= 20"
 	},
 	"dependencies": {
 		"@azure/identity": "^4.1.0",
@@ -78,7 +78,7 @@
 		"@types/mime": "^1",
 		"@types/minimatch": "^3.0.3",
 		"@types/mocha": "^7.0.2",
-		"@types/node": "^22.19.17",
+		"@types/node": "^20.0.0",
 		"@types/read": "^0.0.28",
 		"@types/semver": "^6.0.0",
 		"@types/tmp": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
 		"spec": "src/test/**/*.ts"
 	},
 	"overrides": {
-		"serialize-javascript": "^6.0.2"
+		"serialize-javascript": "7.x"
 	}
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,7 +66,7 @@ export function createVSIX(options: IPackageOptions = {}): Promise<any> {
 	return packageCommand(options);
 }
 
-export type { IPublishOptions } from './publish';
+export type { IPublishOptions, IUnpublishOptions } from './publish';
 
 /**
  * Publishes the extension in the current working directory.

--- a/src/package.ts
+++ b/src/package.ts
@@ -100,7 +100,7 @@ export interface IPackageOptions {
 	 * folders named `win32-x64`, `darwin-arm64` or `web`, the files inside
 	 * those folders will be ignored.
 	 *
-	 * @default false
+	 * @returns false by default
 	 */
 	readonly ignoreOtherTargetFolders?: boolean;
 

--- a/src/test/fixtures/secrets/noSecret2.ts
+++ b/src/test/fixtures/secrets/noSecret2.ts
@@ -1,8 +1,10 @@
 // https://github.com/microsoft/vscode-vsce/issues/1147
+// @ts-ignore
 let privateB64 = '-----BEGIN PRIVATE KEY-----\n';
 privateB64 += 'ABC\n';
 privateB64 += '-----END PRIVATE KEY-----\n';
 
+// @ts-ignore
 const description = ` This is some description test
 
       \`\`\`ini

--- a/src/test/fixtures/secrets/noSecret3.ts
+++ b/src/test/fixtures/secrets/noSecret3.ts
@@ -1,4 +1,7 @@
 // https://github.com/microsoft/vscode-vsce/issues/1153
+// @ts-ignore
 function npm_i_save_dev_types_Slashjest_or_npm_i_(){}
+// @ts-ignore
 function npm_i_save_dev_types_Slash_1_if_it_exists(){}
+// @ts-ignore
 function Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_jQuery_Try_npm_i_save_dev_types_Slashjquery_and_then_add_jquery_to_the_types_field_in_your_tsconfig(){}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
 	"compilerOptions": {
 		"target": "es2020",
-		"module": "commonjs",
+		"module": "nodenext",
 		"moduleResolution": "nodenext",
 		"lib": ["es2020"],
 		"esModuleInterop": true,
 		"outDir": "out",
+		"rootDir": "src",
 		"allowJs": true,
 		"strict": true,
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Fixes build regressions in 3.8.1 by
- Downgrading the node engine and types to 20 again
- Fixing tsconfig (the main issue)
- Silencing test file build errors (false positives)
- Fixing API warnings
