### PR TITLE
update @azure/identity and @azure/msal-node 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@azure/identity": "^4.1.0",
+				"@azure/identity": "^4.13.1",
 				"@secretlint/node": "^10.1.2",
 				"@secretlint/secretlint-formatter-sarif": "^10.1.2",
 				"@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
@@ -229,17 +229,25 @@
 			}
 		},
 		"node_modules/@azure/msal-node": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.2.tgz",
-			"integrity": "sha512-DoeSJ9U5KPAIZoHsPywvfEj2MhBniQe0+FSpjLUTdWoIkI999GB5USkW6nNEHnIaLVxROHXvprWA1KzdS1VQ4A==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
+			"integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
 			"license": "MIT",
 			"dependencies": {
-				"@azure/msal-common": "16.4.1",
-				"jsonwebtoken": "^9.0.0",
-				"uuid": "^8.3.0"
+				"@azure/msal-common": "16.5.2",
+				"jsonwebtoken": "^9.0.0"
 			},
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+			"version": "16.5.2",
+			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
+			"integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -4643,15 +4651,6 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"optional": true
 		},
-		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -5039,13 +5038,19 @@
 			"integrity": "sha512-Bl8f+w37xkXsYh7QRkAKCFGYtWMYuOVO7Lv+BxILrvGz3HbIEF22Pt0ugyj0QPOl6NLrHcnNUQ9yeew98P/5iw=="
 		},
 		"@azure/msal-node": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.2.tgz",
-			"integrity": "sha512-DoeSJ9U5KPAIZoHsPywvfEj2MhBniQe0+FSpjLUTdWoIkI999GB5USkW6nNEHnIaLVxROHXvprWA1KzdS1VQ4A==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
+			"integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
 			"requires": {
-				"@azure/msal-common": "16.4.1",
-				"jsonwebtoken": "^9.0.0",
-				"uuid": "^8.3.0"
+				"@azure/msal-common": "16.5.2",
+				"jsonwebtoken": "^9.0.0"
+			},
+			"dependencies": {
+				"@azure/msal-common": {
+					"version": "16.5.2",
+					"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
+					"integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA=="
+				}
 			}
 		},
 		"@babel/code-frame": {
@@ -8078,11 +8083,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"optional": true
-		},
-		"uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"v8-compile-cache-lib": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": ">= 20"
 	},
 	"dependencies": {
-		"@azure/identity": "^4.1.0",
+		"@azure/identity": "^4.13.1",
 		"@secretlint/node": "^10.1.2",
 		"@secretlint/secretlint-formatter-sarif": "^10.1.2",
 		"@secretlint/secretlint-rule-no-dotenv": "^10.1.2",


### PR DESCRIPTION
to remove transitive dependency on vulnerable uuid package

Fixes GHSA-w5hq-g745-h8pq
