### PR TITLE
Remove redundant secretlint dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
 				"minimatch": "^10.2.2",
 				"parse-semver": "^1.1.1",
 				"read": "^1.0.7",
-				"secretlint": "^10.1.2",
 				"semver": "^7.5.2",
 				"tmp": "^0.2.3",
 				"typed-rest-client": "^1.8.4",
@@ -248,29 +247,6 @@
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -471,41 +447,6 @@
 				"resolve": "~1.22.2"
 			}
 		},
-		"node_modules/@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -637,18 +578,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
-			}
-		},
-		"node_modules/@secretlint/config-creator": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
-			"integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@secretlint/types": "^10.2.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/@secretlint/config-loader": {
@@ -827,18 +756,6 @@
 				"node": ">=20.0.0"
 			}
 		},
-		"node_modules/@sindresorhus/merge-streams": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@textlint/ast-node-types": {
 			"version": "15.7.1",
 			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
@@ -978,12 +895,6 @@
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
-		},
-		"node_modules/@types/normalize-package-data": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-			"license": "MIT"
 		},
 		"node_modules/@types/read": {
 			"version": "0.0.28",
@@ -1469,17 +1380,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dependencies": {
-				"fill-range": "^7.1.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/browser-stdout": {
@@ -2076,22 +1976,6 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
-		"node_modules/fast-glob": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.8"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
 		"node_modules/fast-uri": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -2106,26 +1990,6 @@
 					"url": "https://opencollective.com/fastify"
 				}
 			]
-		},
-		"node_modules/fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-			"license": "ISC",
-			"dependencies": {
-				"reusify": "^1.0.4"
-			}
-		},
-		"node_modules/fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
@@ -2351,37 +2215,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/globby": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-			"integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-			"license": "MIT",
-			"dependencies": {
-				"@sindresorhus/merge-streams": "^2.1.0",
-				"fast-glob": "^3.3.3",
-				"ignore": "^7.0.3",
-				"path-type": "^6.0.0",
-				"slash": "^5.1.0",
-				"unicorn-magic": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/gopd": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2533,15 +2366,6 @@
 			],
 			"optional": true
 		},
-		"node_modules/ignore": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-			"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/import-lazy": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
@@ -2550,18 +2374,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/index-to-position": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
-			"integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/inherits": {
@@ -2607,14 +2419,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -2622,17 +2426,6 @@
 			"optional": true,
 			"dependencies": {
 				"number-is-nan": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-glob": {
-			"version": "4.0.1",
-			"resolved": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz",
-			"integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw= sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-			"dependencies": {
-				"is-extglob": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=0.10.0"
@@ -2654,14 +2447,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"engines": {
-				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/is-path-inside": {
@@ -2735,12 +2520,6 @@
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
 			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -3033,28 +2812,6 @@
 			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
 			"license": "MIT"
 		},
-		"node_modules/merge2": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/micromatch": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"license": "MIT",
-			"dependencies": {
-				"braces": "^3.0.3",
-				"picomatch": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
 		"node_modules/mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz",
@@ -3340,38 +3097,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/normalize-package-data/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/normalize-package-data/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"license": "ISC"
-		},
 		"node_modules/npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -3499,23 +3224,6 @@
 			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
 			"dev": true
 		},
-		"node_modules/parse-json": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"index-to-position": "^1.1.0",
-				"type-fest": "^4.39.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/parse-semver": {
 			"version": "1.1.1",
 			"resolved": "https://registry.yarnpkg.com/parse-semver/-/parse-semver-1.1.1.tgz",
@@ -3586,18 +3294,6 @@
 				"node": "20 || >=22"
 			}
 		},
-		"node_modules/path-type": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-			"integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -3607,18 +3303,8 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
 		},
 		"node_modules/pluralize": {
 			"version": "8.0.0",
@@ -3695,26 +3381,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/queue-microtask": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/rc": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -3751,37 +3417,6 @@
 			},
 			"engines": {
 				"node": ">=0.8"
-			}
-		},
-		"node_modules/read-pkg": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.3",
-				"normalize-package-data": "^6.0.0",
-				"parse-json": "^8.0.0",
-				"type-fest": "^4.6.0",
-				"unicorn-magic": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg/node_modules/unicorn-magic": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/readable-stream": {
@@ -3852,16 +3487,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/reusify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"license": "MIT",
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/run-applescript": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -3872,29 +3497,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -3920,27 +3522,6 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-		},
-		"node_modules/secretlint": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
-			"integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
-			"license": "MIT",
-			"dependencies": {
-				"@secretlint/config-creator": "^10.2.2",
-				"@secretlint/formatter": "^10.2.2",
-				"@secretlint/node": "^10.2.2",
-				"@secretlint/profiler": "^10.2.2",
-				"debug": "^4.4.1",
-				"globby": "^14.1.0",
-				"read-pkg": "^9.0.1"
-			},
-			"bin": {
-				"secretlint": "bin/secretlint.js"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
 		},
 		"node_modules/semver": {
 			"version": "7.5.4",
@@ -4112,18 +3693,6 @@
 				"simple-concat": "^1.0.0"
 			}
 		},
-		"node_modules/slash": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/slice-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -4167,38 +3736,6 @@
 			"dependencies": {
 				"source-map": "^0.5.6"
 			}
-		},
-		"node_modules/spdx-correct": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/spdx-exceptions": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-			"license": "CC-BY-3.0"
-		},
-		"node_modules/spdx-expression-parse": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-			"license": "MIT",
-			"dependencies": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/spdx-license-ids": {
-			"version": "3.0.21",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-			"integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
-			"license": "CC0-1.0"
 		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
@@ -4441,17 +3978,6 @@
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
-		},
 		"node_modules/ts-node": {
 			"version": "10.9.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -4520,18 +4046,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/typed-rest-client": {
 			"version": "1.8.4",
 			"resolved": "https://registry.yarnpkg.com/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
@@ -4573,18 +4087,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/unicorn-magic": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -4610,16 +4112,6 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true
-		},
-		"node_modules/validate-npm-package-license": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
-			}
 		},
 		"node_modules/version-range": {
 			"version": "4.14.0",
@@ -5009,21 +4501,6 @@
 				}
 			}
 		},
-		"@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.1.1"
-			}
-		},
-		"@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="
-		},
 		"@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -5179,29 +4656,6 @@
 				"resolve": "~1.22.2"
 			}
 		},
-		"@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"requires": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
-			}
-		},
-		"@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
-		},
-		"@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"requires": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
-			}
-		},
 		"@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -5293,14 +4747,6 @@
 						"sprintf-js": "~1.0.2"
 					}
 				}
-			}
-		},
-		"@secretlint/config-creator": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
-			"integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
-			"requires": {
-				"@secretlint/types": "^10.2.2"
 			}
 		},
 		"@secretlint/config-loader": {
@@ -5424,11 +4870,6 @@
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
 			"integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg=="
-		},
-		"@sindresorhus/merge-streams": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="
 		},
 		"@textlint/ast-node-types": {
 			"version": "15.7.1",
@@ -5570,11 +5011,6 @@
 			"requires": {
 				"undici-types": "~6.21.0"
 			}
-		},
-		"@types/normalize-package-data": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
 		},
 		"@types/read": {
 			"version": "0.0.28",
@@ -5909,14 +5345,6 @@
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
 					"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
 				}
-			}
-		},
-		"braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"requires": {
-				"fill-range": "^7.1.1"
 			}
 		},
 		"browser-stdout": {
@@ -6315,38 +5743,10 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
-		"fast-glob": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"requires": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.8"
-			}
-		},
 		"fast-uri": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
 			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
-		},
-		"fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-			"requires": {
-				"reusify": "^1.0.4"
-			}
-		},
-		"fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"requires": {
-				"to-regex-range": "^5.0.1"
-			}
 		},
 		"find-up": {
 			"version": "5.0.0",
@@ -6515,27 +5915,6 @@
 				"path-scurry": "^2.0.2"
 			}
 		},
-		"glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"requires": {
-				"is-glob": "^4.0.1"
-			}
-		},
-		"globby": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-			"integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-			"requires": {
-				"@sindresorhus/merge-streams": "^2.1.0",
-				"fast-glob": "^3.3.3",
-				"ignore": "^7.0.3",
-				"path-type": "^6.0.0",
-				"slash": "^5.1.0",
-				"unicorn-magic": "^0.3.0"
-			}
-		},
 		"gopd": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6627,21 +6006,11 @@
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
 			"optional": true
 		},
-		"ignore": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-			"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A=="
-		},
 		"import-lazy": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
 			"integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
 			"dev": true
-		},
-		"index-to-position": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
-			"integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg=="
 		},
 		"inherits": {
 			"version": "2.0.4",
@@ -6669,11 +6038,6 @@
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
 			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="
 		},
-		"is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -6683,14 +6047,6 @@
 				"number-is-nan": "^1.0.0"
 			}
 		},
-		"is-glob": {
-			"version": "4.0.1",
-			"resolved": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz",
-			"integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw= sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-			"requires": {
-				"is-extglob": "^2.1.1"
-			}
-		},
 		"is-inside-container": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -6698,11 +6054,6 @@
 			"requires": {
 				"is-docker": "^3.0.0"
 			}
-		},
-		"is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 		},
 		"is-path-inside": {
 			"version": "3.0.3",
@@ -6751,11 +6102,6 @@
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
 			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
 			"dev": true
-		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "4.2.0",
@@ -6956,20 +6302,6 @@
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
 			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
 		},
-		"merge2": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
-		},
-		"micromatch": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"requires": {
-				"braces": "^3.0.3",
-				"picomatch": "^2.3.1"
-			}
-		},
 		"mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz",
@@ -7169,31 +6501,6 @@
 				"fs-extra": "^11.1.1"
 			}
 		},
-		"normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-			"requires": {
-				"hosted-git-info": "^7.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"dependencies": {
-				"hosted-git-info": {
-					"version": "7.0.2",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-					"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-					"requires": {
-						"lru-cache": "^10.0.1"
-					}
-				},
-				"lru-cache": {
-					"version": "10.4.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-					"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-				}
-			}
-		},
 		"npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -7282,16 +6589,6 @@
 			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
 			"dev": true
 		},
-		"parse-json": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-			"requires": {
-				"@babel/code-frame": "^7.26.2",
-				"index-to-position": "^1.1.0",
-				"type-fest": "^4.39.1"
-			}
-		},
 		"parse-semver": {
 			"version": "1.1.1",
 			"resolved": "https://registry.yarnpkg.com/parse-semver/-/parse-semver-1.1.1.tgz",
@@ -7348,11 +6645,6 @@
 				}
 			}
 		},
-		"path-type": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-			"integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="
-		},
 		"pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -7361,12 +6653,8 @@
 		"picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
-		},
-		"picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true
 		},
 		"pluralize": {
 			"version": "8.0.0",
@@ -7423,11 +6711,6 @@
 				"side-channel": "^1.1.0"
 			}
 		},
-		"queue-microtask": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
-		},
 		"rc": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -7457,25 +6740,6 @@
 			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 			"requires": {
 				"mute-stream": "~0.0.4"
-			}
-		},
-		"read-pkg": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
-			"requires": {
-				"@types/normalize-package-data": "^2.4.3",
-				"normalize-package-data": "^6.0.0",
-				"parse-json": "^8.0.0",
-				"type-fest": "^4.6.0",
-				"unicorn-magic": "^0.1.0"
-			},
-			"dependencies": {
-				"unicorn-magic": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-					"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="
-				}
 			}
 		},
 		"readable-stream": {
@@ -7517,23 +6781,10 @@
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
-		"reusify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
-		},
 		"run-applescript": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
 			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="
-		},
-		"run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"requires": {
-				"queue-microtask": "^1.2.2"
-			}
 		},
 		"safe-buffer": {
 			"version": "5.2.1",
@@ -7544,20 +6795,6 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-		},
-		"secretlint": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
-			"integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
-			"requires": {
-				"@secretlint/config-creator": "^10.2.2",
-				"@secretlint/formatter": "^10.2.2",
-				"@secretlint/node": "^10.2.2",
-				"@secretlint/profiler": "^10.2.2",
-				"debug": "^4.4.1",
-				"globby": "^14.1.0",
-				"read-pkg": "^9.0.1"
-			}
 		},
 		"semver": {
 			"version": "7.5.4",
@@ -7661,11 +6898,6 @@
 				"simple-concat": "^1.0.0"
 			}
 		},
-		"slash": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="
-		},
 		"slice-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -7697,34 +6929,6 @@
 			"requires": {
 				"source-map": "^0.5.6"
 			}
-		},
-		"spdx-correct": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"spdx-exceptions": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
-		},
-		"spdx-expression-parse": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"spdx-license-ids": {
-			"version": "3.0.21",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-			"integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg=="
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
@@ -7901,14 +7105,6 @@
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
 			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="
 		},
-		"to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"requires": {
-				"is-number": "^7.0.0"
-			}
-		},
 		"ts-node": {
 			"version": "10.9.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -7949,11 +7145,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
-		},
 		"typed-rest-client": {
 			"version": "1.8.4",
 			"resolved": "https://registry.yarnpkg.com/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
@@ -7986,11 +7177,6 @@
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true
 		},
-		"unicorn-magic": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
-		},
 		"universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -8012,15 +7198,6 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true
-		},
-		"validate-npm-package-license": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
-			}
 		},
 		"version-range": {
 			"version": "4.14.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
 		"minimatch": "^10.2.2",
 		"parse-semver": "^1.1.1",
 		"read": "^1.0.7",
-		"secretlint": "^10.1.2",
 		"semver": "^7.5.2",
 		"tmp": "^0.2.3",
 		"typed-rest-client": "^1.8.4",


### PR DESCRIPTION
## Summary

- remove the unused `secretlint` CLI package
- retain the `@secretlint/node` engine and all configured rules and formatters
- prune 43 CLI-only transitive packages from the lockfile

## Validation

- Not run, per requested workflow
- Rubber-duck review found no actionable issues and confirmed the removed packages were not reachable from the retained secret-scanning integration