### PR TITLE
Hide OIDC option from publish help

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -209,10 +209,9 @@ module.exports = function (argv: string[]): void {
 		)
 		.option('--azure-credential', 'Use Microsoft Entra ID for authentication')
 		.addOption(
-			new Option('--oidc', 'Use OpenID Connect trusted publishing for authentication').conflicts([
-				'pat',
-				'azureCredential',
-			])
+			new Option('--oidc', 'Use OpenID Connect trusted publishing for authentication')
+				.conflicts(['pat', 'azureCredential'])
+				.hideHelp(true)
 		)
 		.option('-t, --target <targets...>', `Target architectures. Valid targets: ${ValidTargets}`)
 		.option('--ignore-other-target-folders', `Ignore other target folders. Valid only when --target <target> is provided.`)


### PR DESCRIPTION
## Summary
- hide the unannounced `--oidc` option from `vsce publish --help`
- preserve parsing and authentication conflict handling for callers already using it

## Testing
- not run (per request)