### PR TITLE
Add pnpm support for packaging dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"compile": "tsc",
 		"api": "api-extractor run --local --verbose",
 		"build": "npm run compile && npm run api",
+		"prepare": "npm run build",
 		"watch:build": "npm run compile -- --watch",
 		"test": "mocha",
 		"watch:test": "npm run test -- --watch"

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { publish as _publish, IPublishOptions, unpublish as _unpublish, IUnpublishOptions } from './publish';
-import { packageCommand, listFiles as _listFiles, IPackageOptions } from './package';
+import { packageCommand, listFileEntries as _listFileEntries, listFiles as _listFiles, IListFile, IPackageOptions } from './package';
 
 /**
  * @deprecated prefer IPackageOptions instead
@@ -23,6 +23,7 @@ export type ICreateVSIXOptions = Pick<IPackageOptions, 'cwd' | 'packagePath'> & 
 export enum PackageManager {
 	Npm,
 	Yarn,
+	Pnpm,
 	None,
 }
 
@@ -56,7 +57,7 @@ export interface IListFilesOptions {
 	ignoreFile?: string;
 }
 
-export type { IPackageOptions } from './package';
+export type { IListFile, IPackageOptions } from './package';
 
 /**
  * Creates a VSIX from the extension in the current working directory.
@@ -84,6 +85,21 @@ export function listFiles(options: IListFilesOptions = {}): Promise<string[]> {
 	return _listFiles({
 		...options,
 		useYarn: options.packageManager === PackageManager.Yarn,
+		usePnpm: options.packageManager === PackageManager.Pnpm,
+		dependencies: options.packageManager !== PackageManager.None,
+	});
+}
+
+/**
+ * Lists files included in an extension package together with their physical
+ * source paths.
+ * @public
+ */
+export function listFileEntries(options: IListFilesOptions = {}): Promise<IListFile[]> {
+	return _listFileEntries({
+		...options,
+		useYarn: options.packageManager === PackageManager.Yarn,
+		usePnpm: options.packageManager === PackageManager.Pnpm,
 		dependencies: options.packageManager !== PackageManager.None,
 	});
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,6 +70,7 @@ module.exports = function (argv: string[]): void {
 		.option('--tree', 'Prints the files in a tree format', false)
 		.option('--yarn', 'Use yarn instead of npm (default inferred from presence of yarn.lock or .yarnrc)')
 		.option('--no-yarn', 'Use npm instead of yarn (default inferred from absence of yarn.lock or .yarnrc)')
+		.option('--pnpm', 'Use pnpm instead of npm')
 		.option<string[]>(
 			'--packagedDependencies <path>',
 			'Select packages that should be published only (includes dependencies)',
@@ -78,12 +79,12 @@ module.exports = function (argv: string[]): void {
 		)
 		.option('--ignoreFile <path>', 'Indicate alternative .vscodeignore')
 		// default must remain undefined for dependencies or we will fail to load defaults from package.json
-		.option('--dependencies', 'Enable dependency detection via npm or yarn', undefined)
-		.option('--no-dependencies', 'Disable dependency detection via npm or yarn', undefined)
+		.option('--dependencies', 'Enable dependency detection via npm, yarn, or pnpm', undefined)
+		.option('--no-dependencies', 'Disable dependency detection via npm, yarn, or pnpm', undefined)
 		.option('--readme-path <path>', 'Path to README file (defaults to README.md)')
 		.option('--follow-symlinks', 'Recurse into symlinked directories instead of treating them as files')
-		.action(({ tree, yarn, packagedDependencies, ignoreFile, dependencies, readmePath, followSymlinks }) =>
-			main(ls({ tree, useYarn: yarn, packagedDependencies, ignoreFile, dependencies, readmePath, followSymlinks }))
+		.action(({ tree, yarn, pnpm, packagedDependencies, ignoreFile, dependencies, readmePath, followSymlinks }) =>
+			main(ls({ tree, useYarn: yarn, usePnpm: pnpm, packagedDependencies, ignoreFile, dependencies, readmePath, followSymlinks }))
 		);
 
 	program
@@ -114,12 +115,13 @@ module.exports = function (argv: string[]): void {
 		.option('--baseImagesUrl <url>', 'Prepend all relative image links in README.md with the specified URL.')
 		.option('--yarn', 'Use yarn instead of npm (default inferred from presence of yarn.lock or .yarnrc)')
 		.option('--no-yarn', 'Use npm instead of yarn (default inferred from absence of yarn.lock or .yarnrc)')
+		.option('--pnpm', 'Use pnpm instead of npm')
 		.option('--ignoreFile <path>', 'Indicate alternative .vscodeignore')
 		.option('--no-gitHubIssueLinking', 'Disable automatic expansion of GitHub-style issue syntax into links')
 		.option('--no-gitLabIssueLinking', 'Disable automatic expansion of GitLab-style issue syntax into links')
 		// default must remain undefined for dependencies or we will fail to load defaults from package.json
-		.option('--dependencies', 'Enable dependency detection via npm or yarn', undefined)
-		.option('--no-dependencies', 'Disable dependency detection via npm or yarn', undefined)
+		.option('--dependencies', 'Enable dependency detection via npm, yarn, or pnpm', undefined)
+		.option('--no-dependencies', 'Disable dependency detection via npm, yarn, or pnpm', undefined)
 		.option('--pre-release', 'Mark this package as a pre-release')
 		.option('--allow-star-activation', 'Allow using * in activation events')
 		.option('--allow-missing-repository', 'Allow missing a repository URL in package.json')
@@ -148,6 +150,7 @@ module.exports = function (argv: string[]): void {
 					baseContentUrl,
 					baseImagesUrl,
 					yarn,
+					pnpm,
 					ignoreFile,
 					gitHubIssueLinking,
 					gitLabIssueLinking,
@@ -181,6 +184,7 @@ module.exports = function (argv: string[]): void {
 						baseContentUrl,
 						baseImagesUrl,
 						useYarn: yarn,
+						usePnpm: pnpm,
 						ignoreFile,
 						gitHubIssueLinking,
 						gitLabIssueLinking,

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -20,6 +20,8 @@ interface IOptions {
 	killSignal?: string;
 }
 
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'none';
+
 function parseStdout({ stdout }: { stdout: string }): string {
 	return stdout.split(/[\r\n]/).filter(line => !!line)[0];
 }
@@ -195,6 +197,79 @@ async function getYarnDependencies(cwd: string, packagedDependencies?: string[])
 	return [...result];
 }
 
+export interface PnpmDependency {
+	name?: string;
+	from?: string;
+	path: string;
+	dependencies?: Record<string, PnpmDependency>;
+}
+
+export interface DependencyPath {
+	localPath: string;
+	path: string;
+}
+
+export function getPnpmDependencyPaths(roots: PnpmDependency[], packagedDependencies?: string[]): DependencyPath[] {
+	if (roots.length !== 1) {
+		throw new Error(`Expected pnpm to return one project, received ${roots.length}.`);
+	}
+
+	const root = roots[0];
+	const result: DependencyPath[] = [{ localPath: root.path, path: '' }];
+	const seen = new Set<string>();
+	const visit = (name: string, dependency: PnpmDependency, destination: string): void => {
+		const dependencyPath = path.posix.join(destination, 'node_modules', name);
+		const key = `${dependency.path}\0${dependencyPath}`;
+		if (seen.has(key)) {
+			return;
+		}
+		seen.add(key);
+		result.push({ localPath: dependency.path, path: dependencyPath });
+		for (const [childName, child] of Object.entries(dependency.dependencies ?? {})) {
+			visit(childName, child, dependencyPath);
+		}
+	};
+
+	if (packagedDependencies) {
+		for (const name of packagedDependencies) {
+			const dependency = root.dependencies?.[name];
+			if (!dependency) {
+				throw new Error(`Could not find dependency: ${name}`);
+			}
+			visit(name, dependency, '');
+		}
+	} else {
+		for (const [name, dependency] of Object.entries(root.dependencies ?? {})) {
+			visit(name, dependency, '');
+		}
+	}
+
+	return [...result];
+}
+
+export async function getPnpmDependencies(cwd: string, packagedDependencies?: string[]): Promise<DependencyPath[]> {
+	const args = ['list', '--prod', '--json', '--depth', 'Infinity', '--filter', '.'];
+	let result = cp.spawnSync(process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm', args, {
+		cwd,
+		encoding: 'utf8',
+		maxBuffer: 5000 * 1024,
+	});
+	if (result.error && (result.error as NodeJS.ErrnoException).code === 'ENOENT') {
+		result = cp.spawnSync(process.platform === 'win32' ? 'corepack.cmd' : 'corepack', ['pnpm', ...args], {
+			cwd,
+			encoding: 'utf8',
+			maxBuffer: 5000 * 1024,
+		});
+	}
+	if (result.error) {
+		throw result.error;
+	}
+	if (result.status !== 0) {
+		throw new Error(`pnpm list failed with exit code ${result.status}: ${result.stderr}`);
+	}
+	return getPnpmDependencyPaths(JSON.parse(result.stdout) as PnpmDependency[], packagedDependencies);
+}
+
 export async function detectYarn(cwd: string): Promise<boolean> {
 	for (const name of ['yarn.lock', '.yarnrc', '.yarnrc.yaml', '.pnp.cjs', '.yarn']) {
 		if (await exists(path.join(cwd, name))) {
@@ -209,9 +284,13 @@ export async function detectYarn(cwd: string): Promise<boolean> {
 	return false;
 }
 
+export async function detectPnpm(cwd: string): Promise<boolean> {
+	return await exists(path.join(cwd, 'pnpm-lock.yaml'));
+}
+
 export async function getDependencies(
 	cwd: string,
-	dependencies: 'npm' | 'yarn' | 'none' | undefined,
+	dependencies: Exclude<PackageManager, 'pnpm'> | undefined,
 	packagedDependencies?: string[]
 ): Promise<string[]> {
 	if (dependencies === 'none') {

--- a/src/package.ts
+++ b/src/package.ts
@@ -23,7 +23,7 @@ import {
 	validatePublisher,
 	validateExtensionDependencies,
 } from './validation';
-import { detectYarn, getDependencies } from './npm';
+import { DependencyPath, detectPnpm, detectYarn, getDependencies, getPnpmDependencies } from './npm';
 import * as GitHost from 'hosted-git-info';
 import parseSemver from 'parse-semver';
 import * as jsonc from 'jsonc-parser';
@@ -150,6 +150,10 @@ export interface IPackageOptions {
 	 * Should use Yarn instead of NPM.
 	 */
 	readonly useYarn?: boolean;
+	/**
+	 * Should use pnpm instead of npm.
+	 */
+	readonly usePnpm?: boolean;
 	readonly dependencyEntryPoints?: string[];
 	readonly ignoreFile?: string;
 	readonly gitHubIssueLinking?: boolean;
@@ -1633,6 +1637,8 @@ export async function toContentTypes(files: IFile[]): Promise<string> {
 const defaultIgnore = [
 	'.vscodeignore',
 	'package-lock.json',
+	'pnpm-lock.yaml',
+	'pnpm-workspace.yaml',
 	'npm-debug.log',
 	'yarn.lock',
 	'yarn-error.log',
@@ -1665,25 +1671,54 @@ const defaultIgnore = [
 	'**/.vscode-test-web/**',
 ];
 
+interface DependencyFile {
+	path: string;
+	localPath: string;
+}
+
+/** @public */
+export interface IListFile {
+	readonly path: string;
+	readonly localPath: string;
+}
+
 async function collectAllFiles(
 	cwd: string,
-	dependencies: 'npm' | 'yarn' | 'none' | undefined,
+	dependencies: import('./npm').PackageManager | undefined,
 	dependencyEntryPoints?: string[],
 	followSymlinks: boolean = true
-): Promise<string[]> {
-	const deps = await getDependencies(cwd, dependencies, dependencyEntryPoints);
+	): Promise<DependencyFile[]> {
+	let packageManager = dependencies;
+	if (packageManager === undefined) {
+		packageManager = await detectYarn(cwd) ? 'yarn' : await detectPnpm(cwd) ? 'pnpm' : 'npm';
+	}
+	const deps: DependencyPath[] = packageManager === 'pnpm'
+		? await getPnpmDependencies(cwd, dependencyEntryPoints)
+		: (await getDependencies(cwd, packageManager, dependencyEntryPoints)).map(localPath => ({
+			localPath,
+			path: path.relative(cwd, localPath).replace(/\\/g, '/'),
+		}));
 	const promises = deps.map(dep =>
-		glob('**', { cwd: dep, nodir: true, follow: followSymlinks, dot: true, ignore: 'node_modules/**' }).then(files =>
-			files.map(f => path.relative(cwd, path.join(dep, f))).map(f => f.replace(/\\/g, '/'))
+		glob('**', { cwd: dep.localPath, nodir: true, follow: followSymlinks, dot: true, ignore: 'node_modules/**' }).then(files =>
+			files.map(file => ({
+				path: path.posix.join(dep.path, file.replace(/\\/g, '/')),
+				localPath: path.join(dep.localPath, file),
+			}))
 		)
 	);
 
 	return Promise.all(promises).then(util.flatten);
 }
 
-function getDependenciesOption(options: IPackageOptions): 'npm' | 'yarn' | 'none' | undefined {
+function getDependenciesOption(options: IPackageOptions): import('./npm').PackageManager | undefined {
 	if (options.dependencies === false) {
 		return 'none';
+	}
+	if (options.useYarn && options.usePnpm) {
+		throw new Error('Cannot use both yarn and pnpm.');
+	}
+	if (options.usePnpm) {
+		return 'pnpm';
 	}
 
 	switch (options.useYarn) {
@@ -1698,18 +1733,18 @@ function getDependenciesOption(options: IPackageOptions): 'npm' | 'yarn' | 'none
 
 function collectFiles(
 	cwd: string,
-	dependencies: 'npm' | 'yarn' | 'none' | undefined,
+	dependencies: import('./npm').PackageManager | undefined,
 	dependencyEntryPoints?: string[],
 	ignoreFile?: string,
 	manifestFileIncludes?: string[],
 	readmePath?: string,
 	followSymlinks: boolean = false
-): Promise<string[]> {
+	): Promise<DependencyFile[]> {
 	readmePath = readmePath ?? 'README.md';
 	const notIgnored = ['!package.json', `!${readmePath}`];
 
 	return collectAllFiles(cwd, dependencies, dependencyEntryPoints, followSymlinks).then(files => {
-		files = files.filter(f => !/\r$/m.test(f));
+		files = files.filter(file => !/\r$/m.test(file.path));
 
 		return (
 			fs.promises
@@ -1757,9 +1792,9 @@ function collectFiles(
 				// Filter out files
 				.then(({ ignore, negate }) =>
 					files.filter(
-						f =>
-							!ignore.some(i => minimatch(f, i, minimatchOptions)) ||
-							negate.some(i => minimatch(f, i.substr(1), minimatchOptions))
+						file =>
+							!ignore.some(i => minimatch(file.path, i, minimatchOptions)) ||
+							negate.some(i => minimatch(file.path, i.substr(1), minimatchOptions))
 					)
 				)
 		);
@@ -1816,7 +1851,7 @@ export function collect(manifest: ManifestPackage, options: IPackageOptions = {}
 	const processors = createDefaultProcessors(manifest, options);
 
 	return collectFiles(cwd, getDependenciesOption(options), packagedDependencies, ignoreFile, manifest.files, options.readmePath, options.followSymlinks).then(fileNames => {
-		const files = fileNames.map(f => ({ path: util.filePathToVsixPath(f), localPath: path.join(cwd, f) }));
+		const files = fileNames.map(file => ({ path: util.filePathToVsixPath(file.path), localPath: file.localPath }));
 
 		return processFiles(processors, files);
 	});
@@ -1871,16 +1906,20 @@ function getDefaultPackageName(manifest: ManifestPackage, options: IPackageOptio
 	return `${manifest.name}-${version}.vsix`;
 }
 
-export async function prepublish(cwd: string, manifest: ManifestPackage, useYarn?: boolean): Promise<void> {
+export async function prepublish(cwd: string, manifest: ManifestPackage, useYarn?: boolean, usePnpm?: boolean): Promise<void> {
 	if (!manifest.scripts || !manifest.scripts['vscode:prepublish']) {
 		return;
 	}
-
-	if (useYarn === undefined) {
-		useYarn = await detectYarn(cwd);
+	if (useYarn && usePnpm) {
+		throw new Error('Cannot use both yarn and pnpm.');
 	}
 
-	const tool = useYarn ? 'yarn' : 'npm';
+	if (useYarn === undefined && usePnpm === undefined) {
+		useYarn = await detectYarn(cwd);
+		usePnpm = !useYarn && await detectPnpm(cwd);
+	}
+
+	const tool = useYarn ? 'yarn' : usePnpm ? 'pnpm' : 'npm';
 	const prepublish = `${tool} run vscode:prepublish`;
 
 	console.log(`Executing prepublish script '${prepublish}'...`);
@@ -1986,7 +2025,7 @@ export async function packageCommand(options: IPackageOptions = {}): Promise<any
 	const manifest = await readManifest(cwd);
 	util.patchOptionsWithManifest(options, manifest);
 
-	await prepublish(cwd, manifest, options.useYarn);
+	await prepublish(cwd, manifest, options.useYarn, options.usePnpm);
 	await versionBump(options);
 
 	const { packagePath, files } = await pack(options);
@@ -2004,6 +2043,7 @@ export interface IListFilesOptions {
 	readonly cwd?: string;
 	readonly manifest?: ManifestPackage;
 	readonly useYarn?: boolean;
+	readonly usePnpm?: boolean;
 	readonly packagedDependencies?: string[];
 	readonly ignoreFile?: string;
 	readonly dependencies?: boolean;
@@ -2016,11 +2056,19 @@ export interface IListFilesOptions {
  * Lists the files included in the extension's package.
  */
 export async function listFiles(options: IListFilesOptions = {}): Promise<string[]> {
+	return (await listFileEntries(options)).map(file => file.path);
+}
+
+/**
+ * Lists the files included in the extension's package together with their
+ * physical source paths.
+ */
+export async function listFileEntries(options: IListFilesOptions = {}): Promise<IListFile[]> {
 	const cwd = options.cwd ?? process.cwd();
 	const manifest = options.manifest ?? await readManifest(cwd);
 
 	if (options.prepublish) {
-		await prepublish(cwd, manifest, options.useYarn);
+		await prepublish(cwd, manifest, options.useYarn, options.usePnpm);
 	}
 
 	return await collectFiles(cwd, getDependenciesOption(options), options.packagedDependencies, options.ignoreFile, manifest.files, options.readmePath, options.followSymlinks);
@@ -2029,6 +2077,7 @@ export async function listFiles(options: IListFilesOptions = {}): Promise<string
 interface ILSOptions {
 	readonly tree?: boolean;
 	readonly useYarn?: boolean;
+	readonly usePnpm?: boolean;
 	readonly packagedDependencies?: string[];
 	readonly ignoreFile?: string;
 	readonly dependencies?: boolean;

--- a/src/test/npm.test.ts
+++ b/src/test/npm.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import { getPnpmDependencyPaths } from '../npm';
+
+interface TestDependency {
+	name?: string;
+	from?: string;
+	path: string;
+	dependencies?: Record<string, TestDependency>;
+}
+
+describe('pnpm dependencies', () => {
+	const root = (dependencies: Record<string, TestDependency>): TestDependency => ({
+		name: 'extension',
+		path: '/extension',
+		dependencies,
+	});
+
+	it('collects the full production dependency closure', () => {
+		const shared = { from: 'shared', path: '/store/shared' };
+		const result = getPnpmDependencyPaths([root({
+			first: { from: 'first', path: '/store/first', dependencies: { shared } },
+			second: { from: 'second', path: '/store/second', dependencies: { shared } },
+		})]);
+
+		assert.deepStrictEqual(result, [
+			{ localPath: '/extension', path: '' },
+			{ localPath: '/store/first', path: 'node_modules/first' },
+			{ localPath: '/store/shared', path: 'node_modules/first/node_modules/shared' },
+			{ localPath: '/store/second', path: 'node_modules/second' },
+			{ localPath: '/store/shared', path: 'node_modules/second/node_modules/shared' },
+		]);
+	});
+
+	it('collects selected dependency closures', () => {
+		const result = getPnpmDependencyPaths([root({
+			first: { from: 'first', path: '/store/first', dependencies: { child: { from: 'child', path: '/store/child' } } },
+			second: { from: 'second', path: '/store/second' },
+		})], ['first']);
+
+		assert.deepStrictEqual(result, [
+			{ localPath: '/extension', path: '' },
+			{ localPath: '/store/first', path: 'node_modules/first' },
+			{ localPath: '/store/child', path: 'node_modules/first/node_modules/child' },
+		]);
+	});
+
+	it('supports an empty selected dependency list', () => {
+		assert.deepStrictEqual(getPnpmDependencyPaths([root({ first: { path: '/store/first' } })], []), [{ localPath: '/extension', path: '' }]);
+	});
+
+	it('rejects missing selected dependencies', () => {
+		assert.throws(() => getPnpmDependencyPaths([root({})], ['missing']), /Could not find dependency: missing/);
+	});
+
+	it('rejects multiple projects', () => {
+		assert.throws(() => getPnpmDependencyPaths([root({}), root({})]), /Expected pnpm to return one project/);
+	});
+});


### PR DESCRIPTION
This pull request introduces support for pnpm in the project, enhancing the dependency management capabilities. Key changes include:

- Updated `package.json` to include pnpm configurations.
- Refactored `api.ts`, `main.ts`, `npm.ts`, and `package.ts` to accommodate pnpm integration.
- Added a new test file `npm.test.ts` to ensure proper functionality of pnpm support.

These changes aim to improve the overall efficiency and performance of dependency handling in the project.