### PR TITLE
test: prevent watch mode from retriggering

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
 			"ts-node/register"
 		],
 		"watch-files": "src/**",
+		"watch-ignore": "src/test/fixtures/tmp-*",
 		"spec": "src/test/**/*.ts"
 	},
 	"overrides": {


### PR DESCRIPTION
## Summary
- ignore test-generated `src/test/fixtures/tmp-*` directories in Mocha watch mode
- prevent `npm run watch:test` from retriggering indefinitely when tests create temporary fixtures

Fixes #1215.

## Validation
- `npm run compile`
- `npm test` (179 passing; two unrelated Windows failures in the existing `version` test: a 5-second `npm version` timeout and subsequent EPERM cleanup failure)
- `git diff --check`
- verified the Mocha configuration parses with the expected `watch-ignore` glob