### PR TITLE
Bump minimum Node.js version to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       
       - name: Install dependencies
         run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 RUN apk add --update-cache \
     libsecret \
   && rm -rf /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Read the [**Documentation**](https://code.visualstudio.com/api/working-with-exte
 
 ## Requirements
 
-[Node.js](https://nodejs.org/en/) at least `20.x.x`.
+[Node.js](https://nodejs.org/en/) at least `22.x.x`.
 
 ### Linux
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -32,11 +32,11 @@ extends:
           - script: npm run build
         testPlatforms:
           - name: Linux
-            nodeVersions: [20.x]
+            nodeVersions: [22.x]
           - name: MacOS
-            nodeVersions: [20.x]
+            nodeVersions: [22.x]
           - name: Windows
-            nodeVersions: [20.x]
+            nodeVersions: [22.x]
         testSteps:
           - script: npm ci
           - script: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
 				"vsce": "vsce"
 			},
 			"devDependencies": {
-				"@microsoft/api-extractor": "^7.33.7",
+				"@microsoft/api-extractor": "^7.59.0",
 				"@types/cheerio": "^0.22.29",
 				"@types/glob": "^8.1.0",
 				"@types/hosted-git-info": "^3.0.2",
@@ -51,7 +51,7 @@
 				"@types/mime": "^1",
 				"@types/minimatch": "^3.0.3",
 				"@types/mocha": "^7.0.2",
-				"@types/node": "^16.11.7",
+				"@types/node": "^22.20.1",
 				"@types/read": "^0.0.28",
 				"@types/semver": "^6.0.0",
 				"@types/tmp": "^0.2.2",
@@ -59,13 +59,13 @@
 				"@types/xml2js": "^0.4.4",
 				"@types/yauzl": "^2.9.2",
 				"@types/yazl": "^2.4.2",
-				"mocha": "^11.1.0",
+				"mocha": "^11.7.0",
 				"source-map-support": "^0.4.2",
 				"ts-node": "^10.9.1",
-				"typescript": "^4.3.2"
+				"typescript": "^5.9.3"
 			},
 			"engines": {
-				"node": ">= 20"
+				"node": ">= 22"
 			},
 			"optionalDependencies": {
 				"keytar": "^7.7.0"
@@ -437,37 +437,95 @@
 			}
 		},
 		"node_modules/@microsoft/api-extractor": {
-			"version": "7.36.3",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.36.3.tgz",
-			"integrity": "sha512-u0H6362AQq+r55X8drHx4npgkrCfJnMzRRHfQo8PMNKB8TcBnrTLfXhXWi+xnTM6CzlU/netEN8c4bq581Rnrg==",
+			"version": "7.59.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.59.0.tgz",
+			"integrity": "sha512-KDYV8kSVjmG8JJWVg1f1aKxteNG1IQ44D07Rjhlcci8wlqrSFNhUfgv7dJhwT0W2h3NDIL5Vz2f+/DfO4OpDHw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@microsoft/api-extractor-model": "7.27.5",
-				"@microsoft/tsdoc": "0.14.2",
-				"@microsoft/tsdoc-config": "~0.16.1",
-				"@rushstack/node-core-library": "3.59.6",
-				"@rushstack/rig-package": "0.4.0",
-				"@rushstack/ts-command-line": "4.15.1",
-				"colors": "~1.2.1",
-				"lodash": "~4.17.15",
+				"@microsoft/api-extractor-model": "7.33.11",
+				"@microsoft/tsdoc": "~0.16.0",
+				"@microsoft/tsdoc-config": "~0.18.1",
+				"@rushstack/node-core-library": "5.24.0",
+				"@rushstack/rig-package": "0.7.3",
+				"@rushstack/terminal": "0.24.3",
+				"@rushstack/ts-command-line": "5.3.13",
+				"diff": "~8.0.2",
+				"minimatch": "10.2.3",
 				"resolve": "~1.22.1",
-				"semver": "~7.5.4",
+				"semver": "~7.7.4",
 				"source-map": "~0.6.1",
-				"typescript": "~5.0.4"
+				"typescript": "5.9.3"
 			},
 			"bin": {
 				"api-extractor": "bin/api-extractor"
+			},
+			"engines": {
+				"node": ">=20.9.0"
 			}
 		},
 		"node_modules/@microsoft/api-extractor-model": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.27.5.tgz",
-			"integrity": "sha512-9/tBzYMJitR+o+zkPr1lQh2+e8ClcaTF6eZo7vZGDqRt2O5XmXWPbYJZmxyM3wb5at6lfJNEeGZrQXLjsQ0Nbw==",
+			"version": "7.33.11",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.11.tgz",
+			"integrity": "sha512-iDu1AtuRC2Z8XVs2SieZieVavF1FXPBX1C9pMexJh8Dx/Dd/3ZZ4nRQp/PU2Vk2rUHWuBz1wOyL4DcuhVnBXwg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@microsoft/tsdoc": "0.14.2",
-				"@microsoft/tsdoc-config": "~0.16.1",
-				"@rushstack/node-core-library": "3.59.6"
+				"@microsoft/tsdoc": "~0.16.0",
+				"@microsoft/tsdoc-config": "~0.18.1",
+				"@rushstack/node-core-library": "5.24.0"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			}
+		},
+		"node_modules/@microsoft/api-extractor/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@microsoft/api-extractor/node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/@microsoft/api-extractor/node_modules/minimatch": {
+			"version": "10.2.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+			"integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@microsoft/api-extractor/node_modules/source-map": {
@@ -479,48 +537,24 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/@microsoft/api-extractor/node_modules/typescript": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=12.20"
-			}
-		},
 		"node_modules/@microsoft/tsdoc": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
-			"integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
-			"dev": true
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+			"integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@microsoft/tsdoc-config": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
-			"integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+			"integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@microsoft/tsdoc": "0.14.2",
-				"ajv": "~6.12.6",
+				"@microsoft/tsdoc": "0.16.0",
+				"ajv": "~8.18.0",
 				"jju": "~1.4.0",
-				"resolve": "~1.19.0"
-			}
-		},
-		"node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-			"dev": true,
-			"dependencies": {
-				"is-core-module": "^2.1.0",
-				"path-parse": "^1.0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"resolve": "~1.22.2"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -569,18 +603,23 @@
 			}
 		},
 		"node_modules/@rushstack/node-core-library": {
-			"version": "3.59.6",
-			"resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.59.6.tgz",
-			"integrity": "sha512-bMYJwNFfWXRNUuHnsE9wMlW/mOB4jIwSUkRKtu02CwZhQdmzMsUbxE0s1xOLwTpNIwlzfW/YT7OnOHgDffLgYg==",
+			"version": "5.24.0",
+			"resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.24.0.tgz",
+			"integrity": "sha512-g/Z47ZwARn/VkTnHcyJslrR26erRf1G5JbqPlfGZGBCrOcrEt8fTQXXDVhUDDNl/g/v3TXI1dNiAAT5FEks8BA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"colors": "~1.2.1",
-				"fs-extra": "~7.0.1",
+				"ajv": "~8.20.0",
+				"ajv-draft-04": "~1.0.0",
+				"ajv-formats": "~3.0.1",
+				"fs-extra": "~11.3.0",
 				"import-lazy": "~4.0.0",
 				"jju": "~1.4.0",
 				"resolve": "~1.22.1",
-				"semver": "~7.5.4",
-				"z-schema": "~5.0.2"
+				"semver": "~7.7.4"
+			},
+			"engines": {
+				"node": ">=20.9.0"
 			},
 			"peerDependencies": {
 				"@types/node": "*"
@@ -591,38 +630,102 @@
 				}
 			}
 		},
-		"node_modules/@rushstack/rig-package": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.4.0.tgz",
-			"integrity": "sha512-FnM1TQLJYwSiurP6aYSnansprK5l8WUK8VG38CmAaZs29ZeL1msjK0AP1VS4ejD33G0kE/2cpsPsS9jDenBMxw==",
+		"node_modules/@rushstack/node-core-library/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"resolve": "~1.22.1",
-				"strip-json-comments": "~3.1.1"
-			}
-		},
-		"node_modules/@rushstack/rig-package/node_modules/strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@rushstack/problem-matcher": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
+			"integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/node": "*"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rushstack/rig-package": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+			"integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jju": "~1.4.0",
+				"resolve": "~1.22.1"
+			}
+		},
+		"node_modules/@rushstack/terminal": {
+			"version": "0.24.3",
+			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.3.tgz",
+			"integrity": "sha512-KxphDhPGC4xDrKg8O4yrWCEpPMi87aJc1iycXqMVh1dLgV0M34hiH9ZTgWjBRmcrT/OIHoOeWf48npcQFzgp+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rushstack/node-core-library": "5.24.0",
+				"@rushstack/problem-matcher": "0.2.1",
+				"supports-color": "~8.1.1"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"peerDependencies": {
+				"@types/node": "*"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rushstack/terminal/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/@rushstack/ts-command-line": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.15.1.tgz",
-			"integrity": "sha512-EL4jxZe5fhb1uVL/P/wQO+Z8Rc8FMiWJ1G7VgnPDvdIt5GVjRfK7vwzder1CZQiX3x0PY6uxENYLNGTFd1InRQ==",
+			"version": "5.3.13",
+			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.13.tgz",
+			"integrity": "sha512-+jNbxhh8CkrZYxMk9X3GRYM2+Myr1xCCj+eHbJ9Vp+PCdNHS0TUl5QQFT6UbM/aTFRCzs5jiBTKYzBRpe5uYbQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
+				"@rushstack/terminal": "0.24.3",
 				"@types/argparse": "1.0.38",
 				"argparse": "~1.0.9",
-				"colors": "~1.2.1",
 				"string-argv": "~0.3.1"
+			},
+			"engines": {
+				"node": ">=20.9.0"
 			}
 		},
 		"node_modules/@rushstack/ts-command-line/node_modules/argparse": {
@@ -630,6 +733,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -662,28 +766,6 @@
 			"engines": {
 				"node": ">=20.0.0"
 			}
-		},
-		"node_modules/@secretlint/config-loader/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@secretlint/config-loader/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"license": "MIT"
 		},
 		"node_modules/@secretlint/core": {
 			"version": "10.2.2",
@@ -960,7 +1042,8 @@
 			"version": "1.0.38",
 			"resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
 			"integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/cheerio": {
 			"version": "0.22.29",
@@ -1018,10 +1101,14 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.96",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.96.tgz",
-			"integrity": "sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ==",
-			"dev": true
+			"version": "22.20.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+			"integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
 		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.4",
@@ -1254,29 +1341,52 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"dev": true,
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/ansi-colors": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+		"node_modules/ajv-draft-04": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=6"
+			"peerDependencies": {
+				"ajv": "^8.5.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/ansi-escapes": {
@@ -1315,19 +1425,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/anymatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-			"dev": true,
-			"dependencies": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			},
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/aproba": {
@@ -1434,15 +1531,6 @@
 				}
 			],
 			"optional": true
-		},
-		"node_modules/binary-extensions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/binaryextensions": {
 			"version": "6.11.0",
@@ -1624,30 +1712,19 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
 			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://paulmillr.com/funding/"
-				}
-			],
+			"license": "MIT",
 			"dependencies": {
-				"anymatch": "~3.1.2",
-				"braces": "~3.0.2",
-				"glob-parent": "~5.1.2",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.6.0"
+				"readdirp": "^4.0.1"
 			},
 			"engines": {
-				"node": ">= 8.10.0"
+				"node": ">= 14.16.0"
 			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/chownr": {
@@ -1705,15 +1782,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"license": "MIT"
-		},
-		"node_modules/colors": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-			"integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -1871,9 +1939,9 @@
 			}
 		},
 		"node_modules/diff": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+			"integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -2108,12 +2176,6 @@
 				"node": ">=8.6.0"
 			}
 		},
-		"node_modules/fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
-		},
 		"node_modules/fast-uri": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -2232,31 +2294,17 @@
 			"optional": true
 		},
 		"node_modules/fs-extra": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-			"dev": true,
+			"version": "11.3.6",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+			"integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+			"license": "MIT",
 			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=6 <7 || >=8"
-			}
-		},
-		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/function-bind": {
@@ -2471,18 +2519,6 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
 		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz",
-			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y= sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"dependencies": {
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2524,9 +2560,10 @@
 			"optional": true
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -2630,6 +2667,7 @@
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
 			"integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -2658,25 +2696,17 @@
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"optional": true
 		},
-		"node_modules/is-binary-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+		"node_modules/is-core-module": {
+			"version": "2.16.2",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"binary-extensions": "^2.0.0"
+				"hasown": "^2.0.3"
 			},
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/is-core-module": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-			"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
-			"dev": true,
-			"dependencies": {
-				"has": "^1.0.3"
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2733,6 +2763,16 @@
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-unicode-supported": {
@@ -2804,7 +2844,8 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
 			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -2824,10 +2865,10 @@
 			}
 		},
 		"node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",
@@ -2847,10 +2888,13 @@
 			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
 		},
 		"node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"dev": true,
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -2962,12 +3006,6 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
 			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
 		},
-		"node_modules/lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-			"dev": true
-		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -2977,12 +3015,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
 			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-		},
-		"node_modules/lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-			"dev": true
 		},
 		"node_modules/lodash.isinteger": {
 			"version": "4.0.4",
@@ -3186,29 +3218,30 @@
 			"optional": true
 		},
 		"node_modules/mocha": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
-			"integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
+			"version": "11.8.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
+			"integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-colors": "^4.1.3",
 				"browser-stdout": "^1.3.1",
-				"chokidar": "^3.5.3",
+				"chokidar": "^4.0.1",
 				"debug": "^4.3.5",
-				"diff": "^5.2.0",
+				"diff": "^7.0.0",
 				"escape-string-regexp": "^4.0.0",
 				"find-up": "^5.0.0",
 				"glob": "^10.4.5",
 				"he": "^1.2.0",
+				"is-path-inside": "^3.0.3",
 				"js-yaml": "^4.1.0",
 				"log-symbols": "^4.1.0",
-				"minimatch": "^5.1.6",
+				"minimatch": "^9.0.5",
 				"ms": "^2.1.3",
+				"picocolors": "^1.1.1",
 				"serialize-javascript": "^6.0.2",
 				"strip-json-comments": "^3.1.1",
 				"supports-color": "^8.1.1",
-				"workerpool": "^6.5.1",
+				"workerpool": "^9.2.0",
 				"yargs": "^17.7.2",
 				"yargs-parser": "^21.1.1",
 				"yargs-unparser": "^2.0.0"
@@ -3222,9 +3255,9 @@
 			}
 		},
 		"node_modules/mocha/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3263,42 +3296,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/mocha/node_modules/glob/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/mocha/node_modules/glob/node_modules/brace-expansion": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
-			"integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^5.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/mocha/node_modules/jackspeak": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -3323,15 +3320,19 @@
 			"license": "ISC"
 		},
 		"node_modules/mocha/node_modules/minimatch": {
-			"version": "5.1.8",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
-			"integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mocha/node_modules/path-scurry": {
@@ -3425,41 +3426,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/node-sarif-builder/node_modules/fs-extra": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/node-sarif-builder/node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/node-sarif-builder/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
 		"node_modules/normalize-package-data": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
@@ -3491,15 +3457,6 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"license": "ISC"
-		},
-		"node_modules/normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/npmlog": {
 			"version": "4.1.2",
@@ -3683,7 +3640,8 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/path-scurry": {
 			"version": "2.0.0",
@@ -3701,9 +3659,10 @@
 			}
 		},
 		"node_modules/path-scurry/node_modules/lru-cache": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
-			"integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==",
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
 			}
@@ -3792,15 +3751,6 @@
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
-			}
-		},
-		"node_modules/punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/punycode.js": {
@@ -3940,15 +3890,17 @@
 			}
 		},
 		"node_modules/readdirp": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
 			"dev": true,
-			"dependencies": {
-				"picomatch": "^2.2.1"
-			},
+			"license": "MIT",
 			"engines": {
-				"node": ">=8.10.0"
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/require-directory": {
@@ -3971,17 +3923,22 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.22.2",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-			"integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.11.0",
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
 			"bin": {
 				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -4066,12 +4023,10 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -4349,6 +4304,7 @@
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
 			"integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.6.19"
 			}
@@ -4469,6 +4425,7 @@
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -4491,28 +4448,6 @@
 			"engines": {
 				"node": ">=10.0.0"
 			}
-		},
-		"node_modules/table/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/table/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"license": "MIT"
 		},
 		"node_modules/tar-fs": {
 			"version": "2.1.4",
@@ -4698,16 +4633,17 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/uc.micro": {
@@ -4720,6 +4656,13 @@
 			"version": "1.13.8",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
 			"integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unicorn-magic": {
 			"version": "0.3.0",
@@ -4734,21 +4677,12 @@
 			}
 		},
 		"node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true,
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"license": "MIT",
 			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
-		"node_modules/uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
-			"dependencies": {
-				"punycode": "^2.1.0"
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/url-join": {
@@ -4784,16 +4718,6 @@
 			"dependencies": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
-			}
-		},
-		"node_modules/validator": {
-			"version": "13.15.23",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
-			"integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.10"
 			}
 		},
 		"node_modules/version-range": {
@@ -4832,9 +4756,9 @@
 			}
 		},
 		"node_modules/workerpool": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-			"integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+			"version": "9.3.4",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+			"integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -5030,36 +4954,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/z-schema": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-			"integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-			"dev": true,
-			"dependencies": {
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^13.7.0"
-			},
-			"bin": {
-				"z-schema": "bin/z-schema"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"optionalDependencies": {
-				"commander": "^9.4.1"
-			}
-		},
-		"node_modules/z-schema/node_modules/commander": {
-			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-			"dev": true,
-			"optional": true,
-			"engines": {
-				"node": "^12.20.0 || >=14"
 			}
 		}
 	},
@@ -5345,78 +5239,91 @@
 			}
 		},
 		"@microsoft/api-extractor": {
-			"version": "7.36.3",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.36.3.tgz",
-			"integrity": "sha512-u0H6362AQq+r55X8drHx4npgkrCfJnMzRRHfQo8PMNKB8TcBnrTLfXhXWi+xnTM6CzlU/netEN8c4bq581Rnrg==",
+			"version": "7.59.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.59.0.tgz",
+			"integrity": "sha512-KDYV8kSVjmG8JJWVg1f1aKxteNG1IQ44D07Rjhlcci8wlqrSFNhUfgv7dJhwT0W2h3NDIL5Vz2f+/DfO4OpDHw==",
 			"dev": true,
 			"requires": {
-				"@microsoft/api-extractor-model": "7.27.5",
-				"@microsoft/tsdoc": "0.14.2",
-				"@microsoft/tsdoc-config": "~0.16.1",
-				"@rushstack/node-core-library": "3.59.6",
-				"@rushstack/rig-package": "0.4.0",
-				"@rushstack/ts-command-line": "4.15.1",
-				"colors": "~1.2.1",
-				"lodash": "~4.17.15",
+				"@microsoft/api-extractor-model": "7.33.11",
+				"@microsoft/tsdoc": "~0.16.0",
+				"@microsoft/tsdoc-config": "~0.18.1",
+				"@rushstack/node-core-library": "5.24.0",
+				"@rushstack/rig-package": "0.7.3",
+				"@rushstack/terminal": "0.24.3",
+				"@rushstack/ts-command-line": "5.3.13",
+				"diff": "~8.0.2",
+				"minimatch": "10.2.3",
 				"resolve": "~1.22.1",
-				"semver": "~7.5.4",
+				"semver": "~7.7.4",
 				"source-map": "~0.6.1",
-				"typescript": "~5.0.4"
+				"typescript": "5.9.3"
 			},
 			"dependencies": {
+				"balanced-match": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+					"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "5.0.9",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+					"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^4.0.2"
+					}
+				},
+				"diff": {
+					"version": "8.0.4",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+					"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "10.2.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+					"integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^5.0.2"
+					}
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
-				},
-				"typescript": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-					"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-					"dev": true
 				}
 			}
 		},
 		"@microsoft/api-extractor-model": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.27.5.tgz",
-			"integrity": "sha512-9/tBzYMJitR+o+zkPr1lQh2+e8ClcaTF6eZo7vZGDqRt2O5XmXWPbYJZmxyM3wb5at6lfJNEeGZrQXLjsQ0Nbw==",
+			"version": "7.33.11",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.11.tgz",
+			"integrity": "sha512-iDu1AtuRC2Z8XVs2SieZieVavF1FXPBX1C9pMexJh8Dx/Dd/3ZZ4nRQp/PU2Vk2rUHWuBz1wOyL4DcuhVnBXwg==",
 			"dev": true,
 			"requires": {
-				"@microsoft/tsdoc": "0.14.2",
-				"@microsoft/tsdoc-config": "~0.16.1",
-				"@rushstack/node-core-library": "3.59.6"
+				"@microsoft/tsdoc": "~0.16.0",
+				"@microsoft/tsdoc-config": "~0.18.1",
+				"@rushstack/node-core-library": "5.24.0"
 			}
 		},
 		"@microsoft/tsdoc": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
-			"integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+			"integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
 			"dev": true
 		},
 		"@microsoft/tsdoc-config": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
-			"integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+			"integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
 			"dev": true,
 			"requires": {
-				"@microsoft/tsdoc": "0.14.2",
-				"ajv": "~6.12.6",
+				"@microsoft/tsdoc": "0.16.0",
+				"ajv": "~8.18.0",
 				"jju": "~1.4.0",
-				"resolve": "~1.19.0"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.19.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-					"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-					"dev": true,
-					"requires": {
-						"is-core-module": "^2.1.0",
-						"path-parse": "^1.0.6"
-					}
-				}
+				"resolve": "~1.22.2"
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -5450,47 +5357,83 @@
 			"optional": true
 		},
 		"@rushstack/node-core-library": {
-			"version": "3.59.6",
-			"resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.59.6.tgz",
-			"integrity": "sha512-bMYJwNFfWXRNUuHnsE9wMlW/mOB4jIwSUkRKtu02CwZhQdmzMsUbxE0s1xOLwTpNIwlzfW/YT7OnOHgDffLgYg==",
+			"version": "5.24.0",
+			"resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.24.0.tgz",
+			"integrity": "sha512-g/Z47ZwARn/VkTnHcyJslrR26erRf1G5JbqPlfGZGBCrOcrEt8fTQXXDVhUDDNl/g/v3TXI1dNiAAT5FEks8BA==",
 			"dev": true,
 			"requires": {
-				"colors": "~1.2.1",
-				"fs-extra": "~7.0.1",
+				"ajv": "~8.20.0",
+				"ajv-draft-04": "~1.0.0",
+				"ajv-formats": "~3.0.1",
+				"fs-extra": "~11.3.0",
 				"import-lazy": "~4.0.0",
 				"jju": "~1.4.0",
 				"resolve": "~1.22.1",
-				"semver": "~7.5.4",
-				"z-schema": "~5.0.2"
-			}
-		},
-		"@rushstack/rig-package": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.4.0.tgz",
-			"integrity": "sha512-FnM1TQLJYwSiurP6aYSnansprK5l8WUK8VG38CmAaZs29ZeL1msjK0AP1VS4ejD33G0kE/2cpsPsS9jDenBMxw==",
-			"dev": true,
-			"requires": {
-				"resolve": "~1.22.1",
-				"strip-json-comments": "~3.1.1"
+				"semver": "~7.7.4"
 			},
 			"dependencies": {
-				"strip-json-comments": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-					"dev": true
+				"ajv": {
+					"version": "8.20.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+					"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.3",
+						"fast-uri": "^3.0.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2"
+					}
+				}
+			}
+		},
+		"@rushstack/problem-matcher": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
+			"integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
+			"dev": true,
+			"requires": {}
+		},
+		"@rushstack/rig-package": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+			"integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
+			"dev": true,
+			"requires": {
+				"jju": "~1.4.0",
+				"resolve": "~1.22.1"
+			}
+		},
+		"@rushstack/terminal": {
+			"version": "0.24.3",
+			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.3.tgz",
+			"integrity": "sha512-KxphDhPGC4xDrKg8O4yrWCEpPMi87aJc1iycXqMVh1dLgV0M34hiH9ZTgWjBRmcrT/OIHoOeWf48npcQFzgp+g==",
+			"dev": true,
+			"requires": {
+				"@rushstack/node-core-library": "5.24.0",
+				"@rushstack/problem-matcher": "0.2.1",
+				"supports-color": "~8.1.1"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
 		"@rushstack/ts-command-line": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.15.1.tgz",
-			"integrity": "sha512-EL4jxZe5fhb1uVL/P/wQO+Z8Rc8FMiWJ1G7VgnPDvdIt5GVjRfK7vwzder1CZQiX3x0PY6uxENYLNGTFd1InRQ==",
+			"version": "5.3.13",
+			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.13.tgz",
+			"integrity": "sha512-+jNbxhh8CkrZYxMk9X3GRYM2+Myr1xCCj+eHbJ9Vp+PCdNHS0TUl5QQFT6UbM/aTFRCzs5jiBTKYzBRpe5uYbQ==",
 			"dev": true,
 			"requires": {
+				"@rushstack/terminal": "0.24.3",
 				"@types/argparse": "1.0.38",
 				"argparse": "~1.0.9",
-				"colors": "~1.2.1",
 				"string-argv": "~0.3.1"
 			},
 			"dependencies": {
@@ -5524,24 +5467,6 @@
 				"ajv": "^8.17.1",
 				"debug": "^4.4.1",
 				"rc-config-loader": "^4.1.3"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "8.17.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-					"requires": {
-						"fast-deep-equal": "^3.1.3",
-						"fast-uri": "^3.0.1",
-						"json-schema-traverse": "^1.0.0",
-						"require-from-string": "^2.0.2"
-					}
-				},
-				"json-schema-traverse": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-				}
 			}
 		},
 		"@secretlint/core": {
@@ -5814,10 +5739,13 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.18.96",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.96.tgz",
-			"integrity": "sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ==",
-			"dev": true
+			"version": "22.20.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+			"integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+			"dev": true,
+			"requires": {
+				"undici-types": "~6.21.0"
+			}
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.4",
@@ -5971,22 +5899,31 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"dev": true,
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"requires": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			}
 		},
-		"ansi-colors": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-			"dev": true
+		"ajv-draft-04": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+			"dev": true,
+			"requires": {}
+		},
+		"ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"dev": true,
+			"requires": {
+				"ajv": "^8.0.0"
+			}
 		},
 		"ansi-escapes": {
 			"version": "7.0.0",
@@ -6007,16 +5944,6 @@
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"requires": {
 				"color-convert": "^2.0.1"
-			}
-		},
-		"anymatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-			"dev": true,
-			"requires": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
 			}
 		},
 		"aproba": {
@@ -6107,12 +6034,6 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 			"optional": true
-		},
-		"binary-extensions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-			"dev": true
 		},
 		"binaryextensions": {
 			"version": "6.11.0",
@@ -6240,19 +6161,12 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
 			"dev": true,
 			"requires": {
-				"anymatch": "~3.1.2",
-				"braces": "~3.0.2",
-				"fsevents": "~2.3.2",
-				"glob-parent": "~5.1.2",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.6.0"
+				"readdirp": "^4.0.1"
 			}
 		},
 		"chownr": {
@@ -6295,12 +6209,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-		},
-		"colors": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-			"integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
-			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -6411,9 +6319,9 @@
 			"optional": true
 		},
 		"diff": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+			"integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
 			"dev": true
 		},
 		"dom-serializer": {
@@ -6572,12 +6480,6 @@
 				"micromatch": "^4.0.8"
 			}
 		},
-		"fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
-		},
 		"fast-uri": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -6658,22 +6560,14 @@
 			"optional": true
 		},
 		"fs-extra": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-			"dev": true,
+			"version": "11.3.6",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+			"integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
 			}
-		},
-		"fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.2",
@@ -6829,15 +6723,6 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
 		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz",
-			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y= sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6863,9 +6748,9 @@
 			"optional": true
 		},
 		"hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"requires": {
 				"function-bind": "^1.1.2"
 			}
@@ -6947,22 +6832,13 @@
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"optional": true
 		},
-		"is-binary-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-			"dev": true,
-			"requires": {
-				"binary-extensions": "^2.0.0"
-			}
-		},
 		"is-core-module": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-			"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+			"version": "2.16.2",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.3"
 			}
 		},
 		"is-docker": {
@@ -6996,6 +6872,12 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+		},
+		"is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true
 		},
 		"is-unicode-supported": {
 			"version": "0.1.0",
@@ -7060,10 +6942,9 @@
 			}
 		},
 		"json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"json5": {
 			"version": "2.2.3",
@@ -7076,12 +6957,12 @@
 			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
 		},
 		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"dev": true,
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"requires": {
-				"graceful-fs": "^4.1.6"
+				"graceful-fs": "^4.1.6",
+				"universalify": "^2.0.0"
 			}
 		},
 		"jsonwebtoken": {
@@ -7178,12 +7059,6 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
 			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
 		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-			"dev": true
-		},
 		"lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -7193,12 +7068,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
 			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-			"dev": true
 		},
 		"lodash.isinteger": {
 			"version": "4.0.4",
@@ -7348,37 +7217,38 @@
 			"optional": true
 		},
 		"mocha": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
-			"integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
+			"version": "11.8.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
+			"integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
 			"dev": true,
 			"requires": {
-				"ansi-colors": "^4.1.3",
 				"browser-stdout": "^1.3.1",
-				"chokidar": "^3.5.3",
+				"chokidar": "^4.0.1",
 				"debug": "^4.3.5",
-				"diff": "^5.2.0",
+				"diff": "^7.0.0",
 				"escape-string-regexp": "^4.0.0",
 				"find-up": "^5.0.0",
 				"glob": "^10.4.5",
 				"he": "^1.2.0",
+				"is-path-inside": "^3.0.3",
 				"js-yaml": "^4.1.0",
 				"log-symbols": "^4.1.0",
-				"minimatch": "^5.1.6",
+				"minimatch": "^9.0.5",
 				"ms": "^2.1.3",
+				"picocolors": "^1.1.1",
 				"serialize-javascript": "^6.0.2",
 				"strip-json-comments": "^3.1.1",
 				"supports-color": "^8.1.1",
-				"workerpool": "^6.5.1",
+				"workerpool": "^9.2.0",
 				"yargs": "^17.7.2",
 				"yargs-parser": "^21.1.1",
 				"yargs-unparser": "^2.0.0"
 			},
 			"dependencies": {
 				"brace-expansion": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-					"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+					"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0"
@@ -7402,32 +7272,6 @@
 						"minipass": "^7.1.2",
 						"package-json-from-dist": "^1.0.0",
 						"path-scurry": "^1.11.1"
-					},
-					"dependencies": {
-						"balanced-match": {
-							"version": "4.0.4",
-							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-							"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-							"dev": true
-						},
-						"brace-expansion": {
-							"version": "5.0.3",
-							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-							"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-							"dev": true,
-							"requires": {
-								"balanced-match": "^4.0.2"
-							}
-						},
-						"minimatch": {
-							"version": "9.0.7",
-							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
-							"integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
-							"dev": true,
-							"requires": {
-								"brace-expansion": "^5.0.2"
-							}
-						}
 					}
 				},
 				"jackspeak": {
@@ -7447,12 +7291,12 @@
 					"dev": true
 				},
 				"minimatch": {
-					"version": "5.1.8",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
-					"integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
+					"version": "9.0.9",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+					"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^2.0.1"
+						"brace-expansion": "^2.0.2"
 					}
 				},
 				"path-scurry": {
@@ -7520,32 +7364,6 @@
 			"requires": {
 				"@types/sarif": "^2.1.7",
 				"fs-extra": "^11.1.1"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "11.3.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-					"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^6.0.1",
-						"universalify": "^2.0.0"
-					}
-				},
-				"jsonfile": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-					"requires": {
-						"graceful-fs": "^4.1.6",
-						"universalify": "^2.0.0"
-					}
-				},
-				"universalify": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-					"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
-				}
 			}
 		},
 		"normalize-package-data": {
@@ -7572,12 +7390,6 @@
 					"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
 				}
 			}
-		},
-		"normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
 		},
 		"npmlog": {
 			"version": "4.1.2",
@@ -7724,9 +7536,9 @@
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "11.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
-					"integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA=="
+					"version": "11.5.2",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+					"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="
 				}
 			}
 		},
@@ -7791,12 +7603,6 @@
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
 			}
-		},
-		"punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-			"dev": true
 		},
 		"punycode.js": {
 			"version": "2.3.1",
@@ -7887,13 +7693,10 @@
 			}
 		},
 		"readdirp": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-			"dev": true,
-			"requires": {
-				"picomatch": "^2.2.1"
-			}
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -7907,12 +7710,13 @@
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"resolve": {
-			"version": "1.22.2",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-			"integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.11.0",
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
@@ -7955,12 +7759,9 @@
 			}
 		},
 		"semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"requires": {
-				"lru-cache": "^6.0.0"
-			}
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
 		},
 		"serialize-javascript": {
 			"version": "6.0.2",
@@ -8244,24 +8045,6 @@
 				"slice-ansi": "^4.0.0",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "8.17.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-					"requires": {
-						"fast-deep-equal": "^3.1.3",
-						"fast-uri": "^3.0.1",
-						"json-schema-traverse": "^1.0.0",
-						"require-from-string": "^2.0.2"
-					}
-				},
-				"json-schema-traverse": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-				}
 			}
 		},
 		"tar-fs": {
@@ -8388,9 +8171,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true
 		},
 		"uc.micro": {
@@ -8403,25 +8186,21 @@
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
 			"integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
 		},
+		"undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true
+		},
 		"unicorn-magic": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
 			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
 		},
 		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
-		},
-		"uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
 		},
 		"url-join": {
 			"version": "4.0.1",
@@ -8454,12 +8233,6 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"validator": {
-			"version": "13.15.23",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
-			"integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
-			"dev": true
-		},
 		"version-range": {
 			"version": "4.14.0",
 			"resolved": "https://registry.npmjs.org/version-range/-/version-range-4.14.0.tgz",
@@ -8483,9 +8256,9 @@
 			}
 		},
 		"workerpool": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-			"integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+			"version": "9.3.4",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+			"integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
 			"dev": true
 		},
 		"wrap-ansi": {
@@ -8621,27 +8394,6 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true
-		},
-		"z-schema": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-			"integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-			"dev": true,
-			"requires": {
-				"commander": "^9.4.1",
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^13.7.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "9.5.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-					"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-					"dev": true,
-					"optional": true
-				}
-			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"watch:test": "npm run test -- --watch"
 	},
 	"engines": {
-		"node": ">= 20"
+		"node": ">= 22"
 	},
 	"dependencies": {
 		"@azure/identity": "^4.1.0",
@@ -70,7 +70,7 @@
 		"yazl": "^2.2.2"
 	},
 	"devDependencies": {
-		"@microsoft/api-extractor": "^7.33.7",
+		"@microsoft/api-extractor": "^7.59.0",
 		"@types/cheerio": "^0.22.29",
 		"@types/glob": "^8.1.0",
 		"@types/hosted-git-info": "^3.0.2",
@@ -78,7 +78,7 @@
 		"@types/mime": "^1",
 		"@types/minimatch": "^3.0.3",
 		"@types/mocha": "^7.0.2",
-		"@types/node": "^16.11.7",
+		"@types/node": "^22.20.1",
 		"@types/read": "^0.0.28",
 		"@types/semver": "^6.0.0",
 		"@types/tmp": "^0.2.2",
@@ -86,10 +86,10 @@
 		"@types/xml2js": "^0.4.4",
 		"@types/yauzl": "^2.9.2",
 		"@types/yazl": "^2.4.2",
-		"mocha": "^11.1.0",
+		"mocha": "^11.7.0",
 		"source-map-support": "^0.4.2",
 		"ts-node": "^10.9.1",
-		"typescript": "^4.3.2"
+		"typescript": "^5.9.3"
 	},
 	"optionalDependencies": {
 		"keytar": "^7.7.0"


### PR DESCRIPTION
Raises the supported Node.js baseline from 20 to 22.

## Node version bump

| File | Change |
|---|---|
| `package.json` | `engines.node`: `>= 20` → `>= 22` |
| `README.md` | Requirement: `20.x.x` → `22.x.x` |
| `Dockerfile` | `node:18-alpine` → `node:22-alpine` (was lagging two majors behind the declared engine) |
| `.github/workflows/ci.yml` | `node-version`: `20.x` → `22.x` |
| `build/azure-pipelines.yml` | `nodeVersions: [20.x]` → `[22.x]` on Linux/macOS/Windows |

## Supporting toolchain updates

`@types/node` was pinned at `^16` — three majors behind the declared engine, so the codebase was being typechecked against Node 16 APIs. Bumping it to `^22` required several follow-ons:

- **`typescript` `^4.3.2` → `^5.9.3`** — `@types/node@22` requires TS ≥ 5.6. This was not optional: while establishing a baseline I found **TS 4.8 can no longer compile the current dependency tree at all**. `@typespec/ts-http-runtime` and `cheerio` use `export type *` (needs TS 5.0), and `Blob`/`FormData`/`ReadableStream` globals are missing from `@types/node@16`.
- **`@microsoft/api-extractor` `^7.33.7` → `^7.59.0`** — 7.57 bundles TS 5.8 and warned *"target project appears to use TypeScript 5.9.3 which is newer than the bundled compiler engine"*. 7.59.0 bundles 5.9.3 exactly.
- **`mocha` `^11.1.0` → `^11.7.0`** — see below; this one is a genuine Node 22 breakage.
- A stale transitive `lru-cache` under `path-scurry` produced 5 `MapIterator` type errors under TS 5.9. Resolved by letting it float to 11.5.2, already within the existing range. I deliberately did **not** add `skipLibCheck` to paper over it.

## The mocha issue (actual Node 22 breakage)

This is the one that would have broken CI, and it is silent on Node 20.

Node 22.18+ enables **native TypeScript type stripping by default**. mocha's file loader tries `import()` before `require()`. On Node 20, `import()` of a `.ts` file throws `ERR_UNKNOWN_FILE_EXTENSION`, mocha falls back to `require()`, and `ts-node/register` compiles the file. On Node 22.18+, `import()` now *succeeds* in claiming the `.ts` file, so Node's native stripper parses it instead — bypassing ts-node entirely and failing on the angle-bracket type assertion in `src/test/package.test.ts:591`:

```
SyntaxError: The angle-bracket syntax for type assertions, `<T>expr`, is not supported
in type strip mode. Instead, use the 'as' syntax: `expr as T`.
```

mocha 11.7.0 fixed this by branching on `process.features.require_module` and calling `require()` first, which preserves `require.extensions` and keeps ts-node in charge. I bisected the published tarballs to confirm 11.7.0 is the first version containing the fix, and raised the floor accordingly so a fresh resolution cannot pick a broken version.

Worth noting the fix is preferable to rewriting the `<any>` assertion: native stripping only *erases* types, it does not typecheck, so letting it take over would have silently disabled type checking across the whole suite.

## Verification

- **No changes to `src/`** — no logic touched.
- Verified against a real **Node 22.22.1** runtime (≥22.18, so type stripping is default-on — the exact failure condition), not just the local Node 24: `tsc` reports **0 errors**, `api-extractor` succeeds, and all **182 tests pass**. CLI smoke test (`vsce --version`) and `require('./out/api.js')` both work.
- `npm ci` from the updated lockfile → `npm run build` → `npm test` all succeed, matching the pre-change baseline of 182 passing.
- **Public API surface verified unchanged.** I rebuilt `dist/vsce.d.ts` from a clean `npm ci` at `main` and diffed it against the new output. The only difference is a dropped `/// <reference types="node" />`, which is vestigial — the exported API uses only `string`, `Promise<any>`, `Promise<string[]>` and local interfaces, with no `Buffer`/`Stream`/`NodeJS.*` in any type position (`process.` appears only in doc comments). Every other line is byte-identical.
- The lockfile was regenerated from `main`'s committed lockfile rather than reusing pre-existing local drift, so the diff reflects only changes attributable to this bump.

The two remaining api-extractor warnings (`IUnpublishOptions` forgotten-export, `@default` tsdoc tag) are pre-existing and also present on `main`.
