### PR TITLE
Raise Node.js baseline to 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 RUN apk add --update-cache \
     libsecret \
   && rm -rf /var/cache/apk/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
 				"@types/hosted-git-info": "^3.0.2",
 				"@types/mime": "^1",
 				"@types/mocha": "^7.0.2",
-				"@types/node": "^20.0.0",
+				"@types/node": "^22.0.0",
 				"@types/read": "^0.0.28",
 				"@types/semver": "^6.0.0",
 				"@types/url-join": "^4.0.1",
@@ -57,7 +57,7 @@
 				"typescript": "~5.9.0"
 			},
 			"engines": {
-				"node": ">= 20.19"
+				"node": ">= 22"
 			}
 		},
 		"node_modules/@azu/format-text": {
@@ -443,7 +443,6 @@
 			"resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
 			"integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">= 10"
 			},
@@ -1073,9 +1072,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.39",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"version": "22.20.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+			"integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3982,7 +3981,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
 			"integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
-			"optional": true,
 			"requires": {
 				"@napi-rs/keyring-darwin-arm64": "1.3.0",
 				"@napi-rs/keyring-darwin-x64": "1.3.0",
@@ -4377,9 +4375,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "20.19.39",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"version": "22.20.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+			"integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
 			"dev": true,
 			"requires": {
 				"undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"watch:test": "npm run test -- --watch"
 	},
 	"engines": {
-		"node": ">= 20.19"
+		"node": ">= 22"
 	},
 	"dependencies": {
 		"@azure/identity": "^4.1.0",
@@ -72,7 +72,7 @@
 		"@types/hosted-git-info": "^3.0.2",
 		"@types/mime": "^1",
 		"@types/mocha": "^7.0.2",
-		"@types/node": "^20.0.0",
+		"@types/node": "^22.0.0",
 		"@types/read": "^0.0.28",
 		"@types/semver": "^6.0.0",
 		"@types/url-join": "^4.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
 	"compilerOptions": {
-		"target": "es2020",
+		"target": "es2022",
 		"module": "nodenext",
 		"moduleResolution": "nodenext",
-		"lib": ["es2020"],
+		"lib": ["es2024"],
 		"esModuleInterop": true,
 		"outDir": "out",
 		"rootDir": "src",


### PR DESCRIPTION
Raises the supported Node.js baseline from 20 to 22.

CI already targeted Node 22 — `.github/workflows/ci.yml` (`22.x`), `build/azure-pipelines.yml` (`22.x` on Linux/macOS/Windows) and the README requirement (`22.x.x`) all landed previously via #1282. This closes the gap on the parts that were still lagging behind.

## Changes

| File | Change |
|---|---|
| `package.json` | `engines.node`: `>= 20.19` → `>= 22` |
| `package.json` | `@types/node`: `^20.0.0` → `^22.0.0` |
| `Dockerfile` | `node:18-alpine` → `node:22-alpine` — the stalest reference, two LTS lines behind the declared engine |
| `tsconfig.json` | `target`: `es2020` → `es2022`, `lib`: `["es2020"]` → `["es2024"]`, matching the official `@tsconfig/node22` base |

`package-lock.json` regenerated (`@types/node@22.20.1`).

## Verifying no logic breakage

**No changes to `src/`** — no logic touched.

The tsconfig target bump was the only risky part. `target: es2022` flips `useDefineForClassFields` to `true`, changing class fields from `[[Set]]` to `[[Define]]` semantics. That silently breaks code in two patterns: where a derived class redeclares a field the base constructor sets, or where a field shadows a prototype accessor.

I audited all 16 classes in `src/`. No derived class redeclares a base field, and the two getters (`get size()` in `store.ts`, `get isCancelled()` in `util.ts`) are not shadowed by any field.

I then compiled both targets to separate output directories and diffed the emitted JS. All 8 differing files are semantically equivalent — field initializers hoisted to declarations, and numeric separators (`5_000`) preserved rather than stripped. The one ordering shift worth checking was `PublicGalleryAPI`, where `client = new HttpClient('vsce')` now runs before `this.baseUrl` is assigned; that constructor takes only a string literal and never reads `this`, so it is safe.

## Verification

- `npm run build` (tsc + api-extractor) succeeds; api-extractor reports the public API surface written cleanly.
- All **188 tests pass**.

## Note on the lockfile

The regenerated lockfile also drops `"optional": true` from `@napi-rs/keyring` in both lock sections. This is **not** caused by the version bump — I re-ran `npm install --package-lock-only` against the pristine `main` manifest and the same removal occurs, so it is pre-existing drift that npm corrects on any install. It is also the correct state, since that package sits in `dependencies` rather than `optionalDependencies` (its platform-specific `@napi-rs/keyring-*` sub-dependencies remain optional).

## Related

Supersedes the remaining outstanding parts of #1307, which was based on an older merge-base; the rest of that PR (TypeScript 5.9, api-extractor, mocha, CI bumps) has since landed on `main` via #1259, #1282 and #1305.

## Downstream impact

Consumers still installing on Node 20 will now get an `EBADENGINE` warning from npm. That is the intended effect of raising the baseline, but worth flagging.
