### PR TITLE
test: Prevent watch mode from retriggering

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 			"ts-node/register"
 		],
 		"watch-files": "src/**",
+		"watch-ignore": "src/test/fixtures/vsce-test-*",
 		"spec": "src/test/**/*.ts"
 	},
 	"overrides": {


### PR DESCRIPTION
## Summary
- ignore temporary fixture directories created by package tests
- prevent `npm run watch:test` from retriggering when those directories are created or removed

## Validation
- `npm test`
- `npm run build`

Fixes #1215