### PR TITLE
Reduce secretlint dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
 			"dependencies": {
 				"@azure/identity": "^4.1.0",
 				"@napi-rs/keyring": "^1.3.0",
-				"@secretlint/node": "^10.1.2",
+				"@secretlint/core": "^10.1.2",
 				"@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
 				"@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
+				"@secretlint/source-creator": "^10.1.2",
+				"@secretlint/types": "^10.1.2",
 				"@vscode/vsce-sign": "^2.0.0",
 				"azure-devops-node-api": "^12.5.0",
 				"chalk": "^4.1.2",
@@ -59,21 +61,6 @@
 			},
 			"engines": {
 				"node": ">= 22"
-			}
-		},
-		"node_modules/@azu/format-text": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
-			"integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@azu/style-format": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
-			"integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
-			"license": "WTFPL",
-			"dependencies": {
-				"@azu/format-text": "^1.0.1"
 			}
 		},
 		"node_modules/@azure/abort-controller": {
@@ -806,23 +793,6 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
-		"node_modules/@secretlint/config-loader": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
-			"integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@secretlint/profiler": "^10.2.2",
-				"@secretlint/resolver": "^10.2.2",
-				"@secretlint/types": "^10.2.2",
-				"ajv": "^8.17.1",
-				"debug": "^4.4.1",
-				"rc-config-loader": "^4.1.3"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
 		"node_modules/@secretlint/core": {
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
@@ -838,96 +808,10 @@
 				"node": ">=20.0.0"
 			}
 		},
-		"node_modules/@secretlint/formatter": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
-			"integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
-			"license": "MIT",
-			"dependencies": {
-				"@secretlint/resolver": "^10.2.2",
-				"@secretlint/types": "^10.2.2",
-				"@textlint/linter-formatter": "^15.2.0",
-				"@textlint/module-interop": "^15.2.0",
-				"@textlint/types": "^15.2.0",
-				"chalk": "^5.4.1",
-				"debug": "^4.4.1",
-				"pluralize": "^8.0.0",
-				"strip-ansi": "^7.1.0",
-				"table": "^6.9.0",
-				"terminal-link": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@secretlint/formatter/node_modules/ansi-regex": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/@secretlint/formatter/node_modules/chalk": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
-			"integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@secretlint/formatter/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/@secretlint/node": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
-			"integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@secretlint/config-loader": "^10.2.2",
-				"@secretlint/core": "^10.2.2",
-				"@secretlint/formatter": "^10.2.2",
-				"@secretlint/profiler": "^10.2.2",
-				"@secretlint/source-creator": "^10.2.2",
-				"@secretlint/types": "^10.2.2",
-				"debug": "^4.4.1",
-				"p-map": "^7.0.3"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
 		"node_modules/@secretlint/profiler": {
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
 			"integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
-			"license": "MIT"
-		},
-		"node_modules/@secretlint/resolver": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
-			"integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
 			"license": "MIT"
 		},
 		"node_modules/@secretlint/secretlint-rule-no-dotenv": {
@@ -971,56 +855,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@textlint/ast-node-types": {
-			"version": "15.7.1",
-			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
-			"integrity": "sha512-Wii5UgUKFEh9Uv6wbq1zr4/Kf+dtjiUuzPrrXzKp8H+ifkvKNzi23V4Nz+6wVyHQn5T28AFuc8VH8OtzvGYecA=="
-		},
-		"node_modules/@textlint/linter-formatter": {
-			"version": "15.7.1",
-			"resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.7.1.tgz",
-			"integrity": "sha512-TdwZ/debWYFD05K3CcoHtwvnCrza29wZxD+BjDTk/V5N7iRqkK1dTTHSD4A8AIgROLiDkHJmIKQbasbmsg8AvA==",
-			"dependencies": {
-				"@azu/format-text": "^1.0.2",
-				"@azu/style-format": "^1.0.1",
-				"@textlint/module-interop": "15.7.1",
-				"@textlint/resolver": "15.7.1",
-				"@textlint/types": "15.7.1",
-				"chalk": "^4.1.2",
-				"debug": "^4.4.3",
-				"js-yaml": "^4.1.1",
-				"lodash": "^4.18.1",
-				"pluralize": "^2.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"table": "^6.9.0",
-				"text-table": "^0.2.0"
-			}
-		},
-		"node_modules/@textlint/linter-formatter/node_modules/pluralize": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
-			"integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
-			"license": "MIT"
-		},
-		"node_modules/@textlint/module-interop": {
-			"version": "15.7.1",
-			"resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.7.1.tgz",
-			"integrity": "sha512-Jg+sQW2L/cRJypk59wtcMUVVpt8vmit5ZMT3gUnFwevP3A6Qp1HfOtUy9ObT4hBX3lOSGT/ekcCDxR1pL7uH1g=="
-		},
-		"node_modules/@textlint/resolver": {
-			"version": "15.7.1",
-			"resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.7.1.tgz",
-			"integrity": "sha512-8XnO0pgF6mXnm41VvWmBbEIdGPhiCUt31uLZkOis1ECeg/1SoUcIT6Mx/F0e1rukq8l0UlOSeY9a31CsvRMK0g=="
-		},
-		"node_modules/@textlint/types": {
-			"version": "15.7.1",
-			"resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.7.1.tgz",
-			"integrity": "sha512-Vye/GmFNBTgVzZFtIFJTmLB+s2A7oIADxNG6r9UhfPuY+Czv0z5G3xeyFZZudPlfxURsKUyPIU5XsjOFqVp33A==",
-			"dependencies": {
-				"@textlint/ast-node-types": "15.7.1"
 			}
 		},
 		"node_modules/@tsconfig/node10": {
@@ -1317,6 +1151,7 @@
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -1362,25 +1197,11 @@
 				}
 			}
 		},
-		"node_modules/ansi-escapes": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-			"integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
-			"license": "MIT",
-			"dependencies": {
-				"environment": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1409,16 +1230,8 @@
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-		},
-		"node_modules/astral-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -1777,7 +1590,8 @@
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
 		},
 		"node_modules/entities": {
 			"version": "8.0.0",
@@ -1789,18 +1603,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/environment": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-			"integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/es-define-property": {
@@ -1857,12 +1659,14 @@
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
 		},
 		"node_modules/fast-uri": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
 			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2274,6 +2078,7 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
 			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2295,19 +2100,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/json5": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-			"license": "MIT",
-			"bin": {
-				"json5": "lib/cli.js"
-			},
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/jsonc-parser": {
 			"version": "3.2.0",
@@ -2397,6 +2191,7 @@
 			"version": "4.18.1",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
 			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.includes": {
@@ -2439,12 +2234,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
 			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-			"license": "MIT"
-		},
-		"node_modules/lodash.truncate": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
 			"license": "MIT"
 		},
 		"node_modules/log-symbols": {
@@ -2784,18 +2573,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-map": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-			"integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -2870,15 +2647,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/pluralize": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/qs": {
 			"version": "6.15.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -2891,18 +2659,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/rc-config-loader": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
-			"integrity": "sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4",
-				"js-yaml": "^4.1.0",
-				"json5": "^2.2.2",
-				"require-from-string": "^2.0.2"
 			}
 		},
 		"node_modules/read": {
@@ -2944,6 +2700,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -3119,32 +2876,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/slice-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"astral-regex": "^2.0.0",
-				"is-fullwidth-code-point": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
-		"node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3165,6 +2896,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -3202,6 +2934,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3210,6 +2943,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -3250,22 +2984,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/supports-hyperlinks": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
-			}
-		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -3278,44 +2996,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/table": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
-			"integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"ajv": "^8.0.1",
-				"lodash.truncate": "^4.4.2",
-				"slice-ansi": "^4.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/terminal-link": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
-			"integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-escapes": "^7.0.0",
-				"supports-hyperlinks": "^3.2.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/text-table": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"license": "MIT"
 		},
 		"node_modules/textextensions": {
 			"version": "6.11.0",
@@ -3701,19 +3381,6 @@
 		}
 	},
 	"dependencies": {
-		"@azu/format-text": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
-			"integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg=="
-		},
-		"@azu/style-format": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
-			"integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
-			"requires": {
-				"@azu/format-text": "^1.0.1"
-			}
-		},
 		"@azure/abort-controller": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
@@ -4173,19 +3840,6 @@
 				}
 			}
 		},
-		"@secretlint/config-loader": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
-			"integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
-			"requires": {
-				"@secretlint/profiler": "^10.2.2",
-				"@secretlint/resolver": "^10.2.2",
-				"@secretlint/types": "^10.2.2",
-				"ajv": "^8.17.1",
-				"debug": "^4.4.1",
-				"rc-config-loader": "^4.1.3"
-			}
-		},
 		"@secretlint/core": {
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
@@ -4197,68 +3851,10 @@
 				"structured-source": "^4.0.0"
 			}
 		},
-		"@secretlint/formatter": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
-			"integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
-			"requires": {
-				"@secretlint/resolver": "^10.2.2",
-				"@secretlint/types": "^10.2.2",
-				"@textlint/linter-formatter": "^15.2.0",
-				"@textlint/module-interop": "^15.2.0",
-				"@textlint/types": "^15.2.0",
-				"chalk": "^5.4.1",
-				"debug": "^4.4.1",
-				"pluralize": "^8.0.0",
-				"strip-ansi": "^7.1.0",
-				"table": "^6.9.0",
-				"terminal-link": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-					"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="
-				},
-				"chalk": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
-					"integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg=="
-				},
-				"strip-ansi": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-					"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-					"requires": {
-						"ansi-regex": "^6.0.1"
-					}
-				}
-			}
-		},
-		"@secretlint/node": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
-			"integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
-			"requires": {
-				"@secretlint/config-loader": "^10.2.2",
-				"@secretlint/core": "^10.2.2",
-				"@secretlint/formatter": "^10.2.2",
-				"@secretlint/profiler": "^10.2.2",
-				"@secretlint/source-creator": "^10.2.2",
-				"@secretlint/types": "^10.2.2",
-				"debug": "^4.4.1",
-				"p-map": "^7.0.3"
-			}
-		},
 		"@secretlint/profiler": {
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
 			"integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig=="
-		},
-		"@secretlint/resolver": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
-			"integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w=="
 		},
 		"@secretlint/secretlint-rule-no-dotenv": {
 			"version": "10.2.2",
@@ -4286,57 +3882,6 @@
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
 			"integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg=="
-		},
-		"@textlint/ast-node-types": {
-			"version": "15.7.1",
-			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
-			"integrity": "sha512-Wii5UgUKFEh9Uv6wbq1zr4/Kf+dtjiUuzPrrXzKp8H+ifkvKNzi23V4Nz+6wVyHQn5T28AFuc8VH8OtzvGYecA=="
-		},
-		"@textlint/linter-formatter": {
-			"version": "15.7.1",
-			"resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.7.1.tgz",
-			"integrity": "sha512-TdwZ/debWYFD05K3CcoHtwvnCrza29wZxD+BjDTk/V5N7iRqkK1dTTHSD4A8AIgROLiDkHJmIKQbasbmsg8AvA==",
-			"requires": {
-				"@azu/format-text": "^1.0.2",
-				"@azu/style-format": "^1.0.1",
-				"@textlint/module-interop": "15.7.1",
-				"@textlint/resolver": "15.7.1",
-				"@textlint/types": "15.7.1",
-				"chalk": "^4.1.2",
-				"debug": "^4.4.3",
-				"js-yaml": "^4.1.1",
-				"lodash": "^4.18.1",
-				"pluralize": "^2.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"table": "^6.9.0",
-				"text-table": "^0.2.0"
-			},
-			"dependencies": {
-				"pluralize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
-					"integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw=="
-				}
-			}
-		},
-		"@textlint/module-interop": {
-			"version": "15.7.1",
-			"resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.7.1.tgz",
-			"integrity": "sha512-Jg+sQW2L/cRJypk59wtcMUVVpt8vmit5ZMT3gUnFwevP3A6Qp1HfOtUy9ObT4hBX3lOSGT/ekcCDxR1pL7uH1g=="
-		},
-		"@textlint/resolver": {
-			"version": "15.7.1",
-			"resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.7.1.tgz",
-			"integrity": "sha512-8XnO0pgF6mXnm41VvWmBbEIdGPhiCUt31uLZkOis1ECeg/1SoUcIT6Mx/F0e1rukq8l0UlOSeY9a31CsvRMK0g=="
-		},
-		"@textlint/types": {
-			"version": "15.7.1",
-			"resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.7.1.tgz",
-			"integrity": "sha512-Vye/GmFNBTgVzZFtIFJTmLB+s2A7oIADxNG6r9UhfPuY+Czv0z5G3xeyFZZudPlfxURsKUyPIU5XsjOFqVp33A==",
-			"requires": {
-				"@textlint/ast-node-types": "15.7.1"
-			}
 		},
 		"@tsconfig/node10": {
 			"version": "1.0.7",
@@ -4547,6 +4092,7 @@
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4570,18 +4116,11 @@
 				"ajv": "^8.0.0"
 			}
 		},
-		"ansi-escapes": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-			"integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
-			"requires": {
-				"environment": "^1.0.0"
-			}
-		},
 		"ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "4.3.0",
@@ -4600,12 +4139,8 @@
 		"argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-		},
-		"astral-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -4847,17 +4382,13 @@
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
 		},
 		"entities": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
 			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="
-		},
-		"environment": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-			"integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="
 		},
 		"es-define-property": {
 			"version": "1.0.1",
@@ -4897,12 +4428,14 @@
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
 		},
 		"fast-uri": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"dev": true
 		},
 		"fdir": {
 			"version": "6.5.0",
@@ -5155,6 +4688,7 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
 			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"dev": true,
 			"requires": {
 				"argparse": "^2.0.1"
 			}
@@ -5162,12 +4696,8 @@
 		"json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-		},
-		"json5": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
 		},
 		"jsonc-parser": {
 			"version": "3.2.0",
@@ -5237,7 +4767,8 @@
 		"lodash": {
 			"version": "4.18.1",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"dev": true
 		},
 		"lodash.includes": {
 			"version": "4.3.0",
@@ -5273,11 +4804,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
 			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-		},
-		"lodash.truncate": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
 		},
 		"log-symbols": {
 			"version": "4.1.0",
@@ -5501,11 +5027,6 @@
 				}
 			}
 		},
-		"p-map": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-			"integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA=="
-		},
 		"package-json-from-dist": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -5563,28 +5084,12 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
 			"integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="
 		},
-		"pluralize": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
-		},
 		"qs": {
 			"version": "6.15.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
 			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"requires": {
 				"side-channel": "^1.1.0"
-			}
-		},
-		"rc-config-loader": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
-			"integrity": "sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==",
-			"requires": {
-				"debug": "^4.3.4",
-				"js-yaml": "^4.1.0",
-				"json5": "^2.2.2",
-				"require-from-string": "^2.0.2"
 			}
 		},
 		"read": {
@@ -5610,7 +5115,8 @@
 		"require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.22.11",
@@ -5711,23 +5217,6 @@
 				"side-channel-map": "^1.0.1"
 			}
 		},
-		"slice-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-			"requires": {
-				"ansi-styles": "^4.0.0",
-				"astral-regex": "^2.0.0",
-				"is-fullwidth-code-point": "^3.0.0"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				}
-			}
-		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -5744,6 +5233,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -5753,7 +5243,8 @@
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
 				}
 			}
 		},
@@ -5780,6 +5271,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
@@ -5809,46 +5301,11 @@
 				"has-flag": "^4.0.0"
 			}
 		},
-		"supports-hyperlinks": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-			"requires": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			}
-		},
 		"supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
 			"dev": true
-		},
-		"table": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
-			"integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
-			"requires": {
-				"ajv": "^8.0.1",
-				"lodash.truncate": "^4.4.2",
-				"slice-ansi": "^4.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1"
-			}
-		},
-		"terminal-link": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
-			"integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
-			"requires": {
-				"ansi-escapes": "^7.0.0",
-				"supports-hyperlinks": "^3.2.0"
-			}
-		},
-		"text-table": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
 		},
 		"textextensions": {
 			"version": "6.11.0",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
 	"dependencies": {
 		"@azure/identity": "^4.1.0",
 		"@napi-rs/keyring": "^1.3.0",
-		"@secretlint/node": "^10.1.2",
+		"@secretlint/core": "^10.1.2",
 		"@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
 		"@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
+		"@secretlint/source-creator": "^10.1.2",
+		"@secretlint/types": "^10.1.2",
 		"@vscode/vsce-sign": "^2.0.0",
 		"azure-devops-node-api": "^12.5.0",
 		"chalk": "^4.1.2",

--- a/src/secretLint.ts
+++ b/src/secretLint.ts
@@ -100,7 +100,7 @@ async function mapConcurrently<T, U>(values: T[], mapper: (value: T) => Promise<
 		}
 	}
 
-	const workerCount = Math.min(os.cpus().length, values.length);
+	const workerCount = Math.min(os.availableParallelism(), values.length);
 	await Promise.all(Array.from({ length: workerCount }, worker));
 	return results;
 }

--- a/src/secretLint.ts
+++ b/src/secretLint.ts
@@ -1,35 +1,14 @@
 import chalk from "chalk";
+import * as os from "os";
 import * as path from "path";
 import { pathToFileURL } from "url";
+import type {
+	SecretLintCoreConfig,
+	SecretLintCoreResult,
+	SecretLintRuleCreator,
+	SecretLintRulePresetCreator
+} from "@secretlint/types";
 import { log } from "./util";
-
-interface SecretLintEngineResult {
-	ok: boolean;
-	output: string;
-}
-
-type SecretLintSeverity = "error" | "warning" | "info";
-
-interface SecretLintPosition {
-	line: number | null;
-	column: number | null;
-}
-
-interface SecretLintMessage {
-	message: string;
-	ruleId: string;
-	ruleParentId?: string;
-	loc: {
-		start: SecretLintPosition;
-		end: SecretLintPosition;
-	};
-	severity: SecretLintSeverity;
-}
-
-interface SecretLintFileResult {
-	filePath: string;
-	messages: SecretLintMessage[];
-}
 
 interface SecretLintFinding {
 	message: string;
@@ -84,26 +63,46 @@ const dotEnvRules = [
 	}
 ];
 
-async function getEngine(scanSecrets: boolean, scanDotEnv: boolean) {
-	const { createEngine } = require("@secretlint/node") as typeof import("@secretlint/node");
-
-	const rules = [];
+async function getConfig(scanSecrets: boolean, scanDotEnv: boolean): Promise<SecretLintCoreConfig> {
+	const [{ creator: recommend }, { creator: noDotenv }] = await Promise.all([
+		importSecretLintRule<SecretLintRulePresetCreator>("@secretlint/secretlint-rule-preset-recommend"),
+		importSecretLintRule<SecretLintRuleCreator>("@secretlint/secretlint-rule-no-dotenv")
+	]);
+	const rules: SecretLintCoreConfig["rules"] = [];
 	if (scanSecrets) {
-		rules.push(...secretsScanningRules);
+		rules.push({
+			...secretsScanningRules[0],
+			rule: recommend
+		});
 	}
 	if (scanDotEnv) {
-		rules.push(...dotEnvRules);
+		rules.push({
+			...dotEnvRules[0],
+			rule: noDotenv
+		});
 	}
 
-	const lintOptions = {
-		configFileJSON: { rules: rules },
-		formatter: "json",
-		color: true,
-		maskSecrets: false
-	};
+	return { rules };
+}
 
-	const engine = await createEngine(lintOptions);
-	return engine;
+function importSecretLintRule<T>(packageName: string): Promise<{ creator: T }> {
+	return import(packageName);
+}
+
+async function mapConcurrently<T, U>(values: T[], mapper: (value: T) => Promise<U>): Promise<U[]> {
+	const results = new Array<U>(values.length);
+	let nextIndex = 0;
+
+	async function worker() {
+		while (nextIndex < values.length) {
+			const index = nextIndex++;
+			results[index] = await mapper(values[index]);
+		}
+	}
+
+	const workerCount = Math.min(os.cpus().length, values.length);
+	await Promise.all(Array.from({ length: workerCount }, worker));
+	return results;
 }
 
 export async function lintFiles(
@@ -111,19 +110,28 @@ export async function lintFiles(
 	scanSecrets: boolean,
 	scanDotEnv: boolean
 ): Promise<SecretLintResult> {
-	const engine = await getEngine(scanSecrets, scanDotEnv);
-
-	let engineResult;
+	let results;
 	try {
-		engineResult = await engine.executeOnFiles({
-			filePathList: filePaths
-		});
+		const [{ lintSource }, { createRawSource }, config] = await Promise.all([
+			import("@secretlint/core"),
+			import("@secretlint/source-creator"),
+			getConfig(scanSecrets, scanDotEnv)
+		]);
+		results = await mapConcurrently(filePaths, async filePath =>
+			lintSource({
+				source: await createRawSource(filePath),
+				options: {
+					config,
+					maskSecrets: false
+				}
+			})
+		);
 	} catch (error) {
 		log.error('Error occurred while scanning secrets (files):', error);
 		process.exit(1);
 	}
 
-	return parseResult(engineResult);
+	return parseResult(results);
 }
 
 export async function lintText(
@@ -132,28 +140,33 @@ export async function lintText(
 	scanSecrets: boolean,
 	scanDotEnv: boolean
 ): Promise<SecretLintResult> {
-	const engine = await getEngine(scanSecrets, scanDotEnv);
-
-	let engineResult;
+	let result;
 	try {
-		engineResult = await engine.executeOnContent({
-			content,
-			filePath: fileName
+		const [{ lintSource }, config] = await Promise.all([
+			import("@secretlint/core"),
+			getConfig(scanSecrets, scanDotEnv)
+		]);
+		result = await lintSource({
+			source: {
+				content,
+				filePath: fileName,
+				ext: path.extname(fileName),
+				contentType: "text"
+			},
+			options: {
+				config,
+				maskSecrets: false
+			}
 		});
 	} catch (error) {
 		log.error('Error occurred while scanning secrets (content):', error);
 		process.exit(1);
 	}
-	return parseResult(engineResult);
+	return parseResult([result]);
 }
 
-function parseResult(result: SecretLintEngineResult): SecretLintResult {
-	const output: unknown = JSON.parse(result.output);
-	if (!Array.isArray(output) || !output.every(isSecretLintFileResult)) {
-		throw new Error("Unexpected output from secretlint");
-	}
-
-	const results = output.flatMap(fileResult =>
+function parseResult(fileResults: SecretLintCoreResult[]): SecretLintResult {
+	const results = fileResults.flatMap(fileResult =>
 		fileResult.messages.map((message): SecretLintFinding => ({
 			message: message.message,
 			ruleId: message.ruleParentId ? `${message.ruleParentId} > ${message.ruleId}` : message.ruleId,
@@ -168,35 +181,10 @@ function parseResult(result: SecretLintEngineResult): SecretLintResult {
 		}))
 	);
 
-	return { ok: result.ok, results };
-}
-
-function isSecretLintFileResult(value: unknown): value is SecretLintFileResult {
-	return isRecord(value)
-		&& typeof value.filePath === "string"
-		&& Array.isArray(value.messages)
-		&& value.messages.every(isSecretLintMessage);
-}
-
-function isSecretLintMessage(value: unknown): value is SecretLintMessage {
-	return isRecord(value)
-		&& typeof value.message === "string"
-		&& typeof value.ruleId === "string"
-		&& (value.ruleParentId === undefined || typeof value.ruleParentId === "string")
-		&& isRecord(value.loc)
-		&& isSecretLintPosition(value.loc.start)
-		&& isSecretLintPosition(value.loc.end)
-		&& (value.severity === "error" || value.severity === "warning" || value.severity === "info");
-}
-
-function isSecretLintPosition(value: unknown): value is SecretLintPosition {
-	return isRecord(value)
-		&& (value.line === null || typeof value.line === "number")
-		&& (value.column === null || typeof value.column === "number");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
+	return {
+		ok: !fileResults.some(fileResult => fileResult.messages.some(message => message.severity === "error")),
+		results
+	};
 }
 
 function fixLine(value: number | null): number | undefined {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -413,6 +413,21 @@ describe('collect', function () {
 		await processExitExpected(async () => await pack({ cwd, packagePath: getVisxOutputPath(), ignoreFile }), 'Expected package to throw: file which has a private key should not be packaged');
 	});
 
+	it('should scan files when CPU information is unavailable', async function () {
+		const os = require('os') as typeof import('os');
+		const cpusDescriptor = Object.getOwnPropertyDescriptor(os, 'cpus');
+		assert.ok(cpusDescriptor);
+		Object.defineProperty(os, 'cpus', { ...cpusDescriptor, value: () => [] });
+
+		try {
+			const cwd = fixture('secrets');
+			const ignoreFile = path.join(cwd, 'secret1Ignore');
+			await processExitExpected(async () => await pack({ cwd, packagePath: getVisxOutputPath(), ignoreFile }), 'Expected secret scanning to run without CPU information');
+		} finally {
+			Object.defineProperty(os, 'cpus', cpusDescriptor);
+		}
+	});
+
 	it('allow packaging file which has a private key with --allow-package-secrets', async function () {
 		const cwd = fixture('secrets');
 		const ignoreFile = path.join(cwd, 'secret1Ignore');


### PR DESCRIPTION
Much of the secretlint tree (44 deps) can be removed by just doing a little bit in vsce itself, as vsce doesn't actually use all of the config stuff, formatting, etc.