### PR TITLE
cli: add option to suppress new version warning

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,12 +35,12 @@ See https://code.visualstudio.com/api/working-with-extensions/publishing-extensi
 	process.exit(1);
 }
 
-function main(task: Promise<any>): void {
+function main(task: Promise<any>, showNewVersionWarning: boolean): void {
 	let latestVersion: string | null = null;
 
 	const token = new CancellationToken();
 
-	if (isatty(1)) {
+	if (showNewVersionWarning && isatty(1)) {
 		getLatestVersion(pkg.name, token)
 			.then(version => (latestVersion = version))
 			.catch(_ => {
@@ -61,8 +61,12 @@ const ValidTargets = [...Targets].join(', ');
 
 module.exports = function (argv: string[]): void {
 	const program = new Command();
+	const run = (task: Promise<any>): void => main(task, program.opts().newVersionWarning);
 
-	program.version(pkg.version).usage('<command>');
+	program
+		.version(pkg.version)
+		.usage('<command>')
+		.option('--no-new-version-warning', 'Do not show a warning when a newer version is available');
 
 	program
 		.command('ls')
@@ -83,7 +87,7 @@ module.exports = function (argv: string[]): void {
 		.option('--readme-path <path>', 'Path to README file (defaults to README.md)')
 		.option('--follow-symlinks', 'Recurse into symlinked directories instead of treating them as files')
 		.action(({ tree, yarn, packagedDependencies, ignoreFile, dependencies, readmePath, followSymlinks }) =>
-			main(ls({ tree, useYarn: yarn, packagedDependencies, ignoreFile, dependencies, readmePath, followSymlinks }))
+			run(ls({ tree, useYarn: yarn, packagedDependencies, ignoreFile, dependencies, readmePath, followSymlinks }))
 		);
 
 	program
@@ -164,7 +168,7 @@ module.exports = function (argv: string[]): void {
 					followSymlinks,
 				}
 			) =>
-				main(
+				run(
 					packageCommand({
 						packagePath: out,
 						version,
@@ -300,7 +304,7 @@ module.exports = function (argv: string[]): void {
 					followSymlinks,
 				}
 			) =>
-				main(
+				run(
 					publish({
 						pat: oidc ? undefined : pat,
 						azureCredential,
@@ -348,14 +352,14 @@ module.exports = function (argv: string[]): void {
 		.option('-p, --pat <token>', 'Personal Access Token')
 		.option('--azure-credential', 'Use Microsoft Entra ID for authentication')
 		.option('-f, --force', 'Skip confirmation prompt when unpublishing an extension')
-		.action((id, { pat, azureCredential, force }) => main(unpublish({ id, pat, azureCredential, force })));
+		.action((id, { pat, azureCredential, force }) => run(unpublish({ id, pat, azureCredential, force })));
 
 	program
 		.command('generate-manifest')
 		.description('Generates the extension manifest from the provided VSIX package.')
 		.requiredOption('-i, --packagePath <path>', 'Path to the VSIX package')
 		.option('-o, --out <path>', 'Output the extension manifest to <path> location (defaults to <packagename>.manifest)')
-		.action(({ packagePath, out }) => main(generateManifest(packagePath, out)));
+		.action(({ packagePath, out }) => run(generateManifest(packagePath, out)));
 
 	program
 		.command('verify-signature')
@@ -363,27 +367,27 @@ module.exports = function (argv: string[]): void {
 		.requiredOption('-i, --packagePath <path>', 'Path to the VSIX package')
 		.requiredOption('-m, --manifestPath <path>', 'Path to the Manifest file')
 		.requiredOption('-s, --signaturePath <path>', 'Path to the Signature file')
-		.action(({ packagePath, manifestPath, signaturePath }) => main(verifySignature(packagePath, manifestPath, signaturePath)));
+		.action(({ packagePath, manifestPath, signaturePath }) => run(verifySignature(packagePath, manifestPath, signaturePath)));
 
 	program
 		.command('ls-publishers')
 		.description('Lists all known publishers')
-		.action(() => main(listPublishers()));
+		.action(() => run(listPublishers()));
 
 	program
 		.command('delete-publisher <publisher>')
 		.description('Deletes a publisher from marketplace')
-		.action(publisher => main(deletePublisher(publisher)));
+		.action(publisher => run(deletePublisher(publisher)));
 
 	program
 		.command('login <publisher>')
 		.description('Adds a publisher to the list of known publishers')
-		.action(name => main(loginPublisher(name)));
+		.action(name => run(loginPublisher(name)));
 
 	program
 		.command('logout <publisher>')
 		.description('Removes a publisher from the list of known publishers')
-		.action(name => main(logoutPublisher(name)));
+		.action(name => run(logoutPublisher(name)));
 
 	program
 		.command('verify-pat [publisher]')
@@ -394,13 +398,13 @@ module.exports = function (argv: string[]): void {
 			process.env['VSCE_PAT']
 		)
 		.option('--azure-credential', 'Use Microsoft Entra ID for authentication')
-		.action((publisherName, { pat, azureCredential }) => main(verifyPat({ publisherName, pat, azureCredential })));
+		.action((publisherName, { pat, azureCredential }) => run(verifyPat({ publisherName, pat, azureCredential })));
 
 	program
 		.command('show <extensionid>')
 		.description(`Shows an extension's metadata`)
 		.option('--json', 'Outputs data in json format', false)
-		.action((extensionid, { json }) => main(show(extensionid, json)));
+		.action((extensionid, { json }) => run(show(extensionid, json)));
 
 	program
 		.command('search <text>')
@@ -408,7 +412,7 @@ module.exports = function (argv: string[]): void {
 		.option('--json', 'Output results in json format', false)
 		.option('--stats', 'Shows extensions rating and download count', false)
 		.option('-p, --pagesize [value]', 'Number of results to return', '100')
-		.action((text, { json, pagesize, stats }) => main(search(text, json, parseInt(pagesize), stats)));
+		.action((text, { json, pagesize, stats }) => run(search(text, json, parseInt(pagesize), stats)));
 
 	program.on('command:*', ([cmd]: string) => {
 		if (cmd === 'create-publisher') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ module.exports = function (argv: string[]): void {
 	program
 		.version(pkg.version)
 		.usage('<command>')
-		.option('--no-new-version-warning', 'Do not show a warning when a newer version is available');
+		.option('--no-new-version-warning', 'Suppress the warning shown when a newer version of vsce is available');
 
 	program
 		.command('ls')


### PR DESCRIPTION
## Summary

- add a global `--no-new-version-warning` option
- skip the npm version check when the option is used
- preserve the existing warning behavior by default for every command

Fixes #1201

## Validation

- `npm run compile`
- `npm test` (249 passing, 3 pending)
- verified the option appears in help and is accepted before or after a subcommand