### PR TITLE
Support extensionless .mjs entrypoints

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -1121,7 +1121,7 @@ class LaunchEntryPointProcessor extends BaseProcessor {
 	}
 
 	private hasSeenEntrypointFile(filePath: string): boolean {
-		return this.seenFiles.has(filePath) || this.seenFiles.has(filePath + '.js');
+		return this.seenFiles.has(filePath) || this.seenFiles.has(filePath + '.js') || this.seenFiles.has(filePath + '.mjs');
 	}
 
 	async onEnd(): Promise<void> {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -2402,6 +2402,12 @@ describe('LaunchEntryPointProcessor', () => {
 		await _toVsixManifest(manifest, files);
 	});
 
+	it('should work even if .mjs extension is not used', async () => {
+		const manifest = createManifest({ main: 'out/src/extension' });
+		const files = [{ path: 'extension/out/src/extension.mjs', contents: Buffer.from('') }];
+		await _toVsixManifest(manifest, files);
+	});
+
 	it('should accept manifest if no entrypoints defined', async () => {
 		const manifest = createManifest({});
 		const files = [{ path: 'extension/something.js', contents: Buffer.from('') }];


### PR DESCRIPTION
## Summary
- recognize `.mjs` files when an extension manifest omits the entrypoint suffix
- add coverage for extensionless ESM entrypoints

Fixes #1273

## Validation
- `npm test -- --grep "LaunchEntryPointProcessor"`
- `npm run compile`
