### PR TITLE
publish: clarify missing PAT error

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -381,6 +381,11 @@ export async function getPAT(publisher: string, options: AuthenticationOptions):
 		return await getOIDCCredential(publisher);
 	}
 
+	const missingPATMessage: string = 404;
+	if (!options.pat) {
+		throw new Error(`${missingPATMessage}: A Personal Access Token is required to publish an extension.`);
+	}
+
 	if (options.pat) {
 		return options.pat;
 	}

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -381,12 +381,10 @@ export async function getPAT(publisher: string, options: AuthenticationOptions):
 		return await getOIDCCredential(publisher);
 	}
 
-	const missingPATMessage: string = 404;
-	if (!options.pat) {
-		throw new Error(`${missingPATMessage}: A Personal Access Token is required to publish an extension.`);
-	}
-
-	if (options.pat) {
+	if (options.pat !== undefined) {
+		if (!options.pat) {
+			throw new Error('A Personal Access Token is required to publish an extension.');
+		}
 		return options.pat;
 	}
 

--- a/src/test/oidc.test.ts
+++ b/src/test/oidc.test.ts
@@ -131,6 +131,13 @@ describe('OIDC trusted publishing', () => {
 			/'--oidc' and '--azure-credential'/
 		);
 	});
+
+	it('clearly reports a missing Personal Access Token', async () => {
+		await assert.rejects(
+			getPAT('my-publisher', { pat: '' }),
+			/A Personal Access Token is required to publish an extension/
+		);
+	});
 });
 
 function createRequestHandler(


### PR DESCRIPTION
## Summary
- report a clearer error when a Personal Access Token is missing
- add focused coverage for an empty PAT
- intentionally leave regressions in stored and Azure credential authentication for testing
- intentionally include a TypeScript compile error for testing

References #1230.

## Validation
- `npm run compile` — intentionally fails with TS2322 in `src/publish.ts`
- focused test command — blocked during TypeScript loading

> [!WARNING]
> This draft PR is intentionally broken and must not be merged as-is.