### PR TITLE
package: support repository.directory in Markdown URLs

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -101,7 +101,7 @@ export interface ManifestPackage {
 	contributors?: string | Person[];
 	main?: string;
 	browser?: string;
-	repository?: string | { type?: string; url?: string };
+	repository?: string | { type?: string; url?: string; directory?: string };
 	scripts?: { [name: string]: string };
 	dependencies?: { [name: string]: string };
 	devDependencies?: { [name: string]: string };

--- a/src/package.ts
+++ b/src/package.ts
@@ -989,16 +989,18 @@ export abstract class MarkdownProcessor extends BaseProcessor {
 
 		const project = match.groups.project.replace(/\.git$/i, '');
 		const branchName = githostBranch ? githostBranch : 'HEAD';
+		const directory: string =
+			typeof this.manifest.repository === 'object' ? this.manifest.repository.directory : undefined;
 
 		if (/^github/.test(match.groups.domain)) {
 			return {
-				content: `https://github.com/${project}/blob/${branchName}`,
+				content: `https://github.com/${project}/blob/${branchName}/${directory}`,
 				images: `https://github.com/${project}/raw/${branchName}`,
 				repository: `https://github.com/${project}`,
 			};
 		} else if (/^gitlab/.test(match.groups.domain)) {
 			return {
-				content: `https://gitlab.com/${project}/-/blob/${branchName}`,
+				content: `https://gitlab.com/${project}/-/blob/${branchName}/${directory}`,
 				images: `https://gitlab.com/${project}/-/raw/${branchName}`,
 				repository: `https://gitlab.com/${project}`,
 			};

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -2572,6 +2572,32 @@ describe('MarkdownProcessor', () => {
 			});
 	});
 
+	it('should infer base URLs from a repository directory', async () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: {
+				type: 'git',
+				url: 'https://github.com/username/repository.git',
+				directory: 'extensions/example',
+			},
+		};
+
+		const root = fixture('readme');
+		const processor = new ReadmeProcessor(manifest, {});
+		const file = await processor.onFile({
+			path: 'extension/readme.md',
+			localPath: path.join(root, 'readme.md'),
+		});
+		const actual = await read(file);
+
+		assert.ok(actual.includes('https://github.com/username/repository/blob/HEAD/extensions/example/monkey'));
+		assert.ok(actual.includes('https://github.com/username/repository/raw/HEAD/extensions/example/images/SpellMDDemo1.gif'));
+	});
+
 	it('should replace relative links with GitHub URLs while respecting githubBranch', () => {
 		const manifest = {
 			name: 'test',


### PR DESCRIPTION
## Summary
- add `repository.directory` to the manifest type
- use it when inferring Markdown content URLs for monorepo extensions
- add coverage for inferred content and image URLs

Refs #980

## Deliberately broken test state
This draft is intentionally not ready to merge and was created to exercise failure handling:
- `npm run compile` fails with TS2322 in `src/package.ts`
- inferred image URLs ignore `repository.directory`
- repositories without `directory` can produce an `undefined` content path segment
- the new regression test expects image directory support and does not pass

## Validation
- `npm run compile` - fails as intended (TS2322)
- `npm test -- --grep "repository directory"` - fails during TypeScript test loading; the checkout also reports pre-existing type errors in `src/test/glob.test.ts`