### PR TITLE
Replace form-data with Node streams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
                 "azure-devops-node-api": "^12.5.0",
                 "cockatiel": "^3.2.1",
                 "commander": "^12.1.0",
-                "form-data": "^4.0.6",
                 "hosted-git-info": "^4.1.0",
                 "jsonc-parser": "^3.3.1",
                 "leven": "^3.1.0",
@@ -88,9 +87,9 @@
             }
         },
         "node_modules/@azure/core-client": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.0.tgz",
-            "integrity": "sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.1.tgz",
+            "integrity": "sha512-2QygG2F76ZpMP2eMztiJvAiFMu71M9rDeU7vO/QKg5Css7MgM4frUOslFjhVjRhbGaCNPtz/S8M6y46/fFKVuQ==",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.1.2",
@@ -936,9 +935,9 @@
             }
         },
         "node_modules/@typespec/ts-http-runtime": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
-            "integrity": "sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==",
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.9.tgz",
+            "integrity": "sha512-edSdeAqkdxBVzA1yL1LrLCml1YjyCVvPMtMqJpbF+6K609tHe8V6sQUzFQSGcYNhcuhOceZtjvN32+mpIth30A==",
             "license": "MIT",
             "dependencies": {
                 "http-proxy-agent": "^7.0.0",
@@ -1214,12 +1213,6 @@
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
-        },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "license": "MIT"
         },
         "node_modules/azure-devops-node-api": {
             "version": "12.5.0",
@@ -1505,18 +1498,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/commander": {
             "version": "12.1.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -1616,15 +1597,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/diff": {
@@ -1727,21 +1699,6 @@
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1853,22 +1810,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.4",
-                "mime-types": "^2.1.35"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/fs-extra": {
@@ -2031,21 +1972,6 @@
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2510,27 +2436,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
 		"azure-devops-node-api": "^12.5.0",
 		"cockatiel": "^3.2.1",
 		"commander": "^12.1.0",
-		"form-data": "^4.0.6",
 		"hosted-git-info": "^4.1.0",
 		"jsonc-parser": "^3.3.1",
 		"leven": "^3.1.0",

--- a/src/multipart.ts
+++ b/src/multipart.ts
@@ -13,6 +13,11 @@ function escapeHeaderParameter(value: string): string {
 export function createMultipartStream(parts: readonly MultipartPart[], boundary: string): Readable {
 	const lineBreak = '\r\n';
 
+	for (const part of parts) {
+		// Readable's async iterator will rethrow stored errors when this part is consumed.
+		part.stream.on('error', () => {});
+	}
+
 	return Readable.from(
 		(async function* () {
 			for (const part of parts) {

--- a/src/multipart.ts
+++ b/src/multipart.ts
@@ -32,3 +32,25 @@ export function createMultipartStream(parts: readonly MultipartPart[], boundary:
 		})()
 	);
 }
+
+export function runWithStreamError<T>(stream: Readable, operation: () => Promise<T>): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const cleanup = () => stream.off('error', onStreamError);
+		const onStreamError = (error: Error) => {
+			cleanup();
+			reject(error);
+		};
+
+		stream.once('error', onStreamError);
+		Promise.resolve().then(operation).then(
+			result => {
+				cleanup();
+				resolve(result);
+			},
+			error => {
+				cleanup();
+				reject(error);
+			}
+		);
+	});
+}

--- a/src/multipart.ts
+++ b/src/multipart.ts
@@ -14,43 +14,52 @@ export function createMultipartStream(parts: readonly MultipartPart[], boundary:
 	const lineBreak = '\r\n';
 
 	for (const part of parts) {
-		// Readable's async iterator will rethrow stored errors when this part is consumed.
+		// A part can fail before it is reached. Readable stores the error and its async iterator
+		// rethrows it when the part is consumed; this listener just keeps it from being unhandled.
 		part.stream.on('error', () => {});
 	}
 
-	return Readable.from(
-		(async function* () {
-			for (const part of parts) {
-				yield `--${boundary}${lineBreak}`;
-				yield `Content-Disposition: attachment; name=${escapeHeaderParameter(part.name)}; filename="${escapeHeaderParameter(part.filename)}"${lineBreak}`;
-				yield `Content-Type: application/octet-stream${lineBreak}${lineBreak}`;
-				yield* part.stream;
-				yield lineBreak;
-			}
+	const destroyParts = () => {
+		for (const part of parts) {
+			part.stream.destroy();
+		}
+	};
 
-			yield `--${boundary}--${lineBreak}`;
-		})()
+	const stream = Readable.from(
+		(async function* () {
+			try {
+				for (const part of parts) {
+					yield `--${boundary}${lineBreak}` +
+						`Content-Disposition: attachment; name=${escapeHeaderParameter(part.name)}; filename="${escapeHeaderParameter(part.filename)}"${lineBreak}` +
+						`Content-Type: application/octet-stream${lineBreak}${lineBreak}`;
+					yield* part.stream;
+					yield lineBreak;
+				}
+
+				yield `--${boundary}--${lineBreak}`;
+			} finally {
+				// Parts after a failed or abandoned one are never consumed, so release them here.
+				destroyParts();
+			}
+		})(),
+		// Without this the stream emits 'close' once it ends, which makes consumers that treat
+		// 'close' as "the body is complete" end the underlying request a second time.
+		{ autoDestroy: false }
 	);
+
+	// The generator body, and therefore its `finally`, never runs if the stream is destroyed
+	// before anything is read from it.
+	stream.on('close', destroyParts);
+
+	return stream;
 }
 
 export function runWithStreamError<T>(stream: Readable, operation: () => Promise<T>): Promise<T> {
 	return new Promise<T>((resolve, reject) => {
-		const cleanup = () => stream.off('error', onStreamError);
-		const onStreamError = (error: Error) => {
-			cleanup();
-			reject(error);
-		};
-
-		stream.once('error', onStreamError);
-		Promise.resolve().then(operation).then(
-			result => {
-				cleanup();
-				resolve(result);
-			},
-			error => {
-				cleanup();
-				reject(error);
-			}
-		);
+		// This listener is deliberately never removed. An error arriving after the operation has
+		// settled would otherwise be an unhandled 'error' event, which terminates the process.
+		// Settling a promise more than once is a no-op, so the first outcome wins.
+		stream.on('error', reject);
+		Promise.resolve().then(operation).then(resolve, reject);
 	});
 }

--- a/src/multipart.ts
+++ b/src/multipart.ts
@@ -1,0 +1,29 @@
+import { Readable } from 'stream';
+
+export interface MultipartPart {
+	name: string;
+	filename: string;
+	stream: Readable;
+}
+
+function escapeHeaderParameter(value: string): string {
+	return value.replace(/\r/g, '%0D').replace(/\n/g, '%0A').replace(/"/g, '%22');
+}
+
+export function createMultipartStream(parts: readonly MultipartPart[], boundary: string): Readable {
+	const lineBreak = '\r\n';
+
+	return Readable.from(
+		(async function* () {
+			for (const part of parts) {
+				yield `--${boundary}${lineBreak}`;
+				yield `Content-Disposition: attachment; name=${escapeHeaderParameter(part.name)}; filename="${escapeHeaderParameter(part.filename)}"${lineBreak}`;
+				yield `Content-Type: application/octet-stream${lineBreak}${lineBreak}`;
+				yield* part.stream;
+				yield lineBreak;
+			}
+
+			yield `--${boundary}--${lineBreak}`;
+		})()
+	);
+}

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -311,9 +311,17 @@ async function _publishSignedPackage(api: GalleryApi, packagePath: string, sigzi
 			'0f411892-ef48-488f-89d3-4f0546e84723'
 		);
 
-		return await runWithStreamError(form, () =>
-			api.publishExtensionWithPublisherSignature(undefined, form, manifest.publisher, manifest.name, extensionType)
-		);
+		try {
+			return await runWithStreamError(form, () =>
+				api.publishExtensionWithPublisherSignature(undefined, form, manifest.publisher, manifest.name, extensionType)
+			);
+		} finally {
+			// Release the file handles when the request did not consume the whole form, which
+			// otherwise keeps the package locked until the process exits.
+			if (!form.readableEnded) {
+				form.destroy();
+			}
+		}
 	});
 }
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -8,12 +8,12 @@ import { ManifestPackage, ManifestPublish } from './manifest';
 import { readVSIXPackage } from './zip';
 import { validatePublisher } from './validation';
 import { GalleryApi } from 'azure-devops-node-api/GalleryApi';
-import FormData from 'form-data';
 import { basename, join } from 'path';
 import { tmpdir } from 'os';
 import { IterableBackoff, handleWhen, retry } from 'cockatiel';
 import { getAzureCredentialAccessToken } from './auth';
 import { getOIDCCredential } from './oidc';
+import { createMultipartStream } from './multipart';
 
 async function withTemporaryPackage<T>(fn: (packagePath: string) => Promise<T>): Promise<T> {
 	const directory = await fs.promises.mkdtemp(join(tmpdir(), 'vsce-'));
@@ -297,15 +297,13 @@ async function _publish(packagePath: string, sigzipPath: string | undefined, man
 
 async function _publishSignedPackage(api: GalleryApi, packageName: string, packageStream: fs.ReadStream, sigzipName: string, sigzipStream: fs.ReadStream, manifest: ManifestPublish) {
 	const extensionType = 'Visual Studio Code';
-	const form = new FormData();
-	const lineBreak = '\r\n';
-	form.setBoundary('0f411892-ef48-488f-89d3-4f0546e84723');
-	form.append('vsix', packageStream, {
-		header: `--${form.getBoundary()}${lineBreak}Content-Disposition: attachment; name=vsix; filename=\"${packageName}\"${lineBreak}Content-Type: application/octet-stream${lineBreak}${lineBreak}`
-	});
-	form.append('sigzip', sigzipStream, {
-		header: `--${form.getBoundary()}${lineBreak}Content-Disposition: attachment; name=sigzip; filename=\"${sigzipName}\"${lineBreak}Content-Type: application/octet-stream${lineBreak}${lineBreak}`
-	});
+	const form = createMultipartStream(
+		[
+			{ name: 'vsix', filename: packageName, stream: packageStream },
+			{ name: 'sigzip', filename: sigzipName, stream: sigzipStream },
+		],
+		'0f411892-ef48-488f-89d3-4f0546e84723'
+	);
 
 	const publishWithRetry = retry(handleWhen(err => err.message.includes('timeout')), {
 		maxAttempts: 3,

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'os';
 import { IterableBackoff, handleWhen, retry } from 'cockatiel';
 import { getAzureCredentialAccessToken } from './auth';
 import { getOIDCCredential } from './oidc';
-import { createMultipartStream } from './multipart';
+import { createMultipartStream, runWithStreamError } from './multipart';
 
 async function withTemporaryPackage<T>(fn: (packagePath: string) => Promise<T>): Promise<T> {
 	const directory = await fs.promises.mkdtemp(join(tmpdir(), 'vsce-'));
@@ -213,7 +213,6 @@ export interface IInternalPublishOptions {
 async function _publish(packagePath: string, sigzipPath: string | undefined, manifest: ManifestPublish, options: IInternalPublishOptions) {
 	const pat = await getPAT(manifest.publisher, options);
 	const api = await getGalleryAPI(pat);
-	const packageStream = fs.createReadStream(packagePath);
 	const name = `${manifest.publisher}.${manifest.name}`;
 	const description = options.target
 		? `${name} (${options.target}) v${manifest.version}`
@@ -254,10 +253,10 @@ async function _publish(packagePath: string, sigzipPath: string | undefined, man
 			}
 
 			if (sigzipPath) {
-				await _publishSignedPackage(api, basename(packagePath), packageStream, basename(sigzipPath), fs.createReadStream(sigzipPath), manifest);
+				await _publishSignedPackage(api, packagePath, sigzipPath, manifest);
 			} else {
 				try {
-					await api.updateExtension(undefined, packageStream, manifest.publisher, manifest.name);
+					await api.updateExtension(undefined, fs.createReadStream(packagePath), manifest.publisher, manifest.name);
 				} catch (err: any) {
 					if (err.statusCode === 409) {
 						if (options.skipDuplicate) {
@@ -273,9 +272,9 @@ async function _publish(packagePath: string, sigzipPath: string | undefined, man
 			}
 		} else {
 			if (sigzipPath) {
-				await _publishSignedPackage(api, basename(packagePath), packageStream, basename(sigzipPath), fs.createReadStream(sigzipPath), manifest);
+				await _publishSignedPackage(api, packagePath, sigzipPath, manifest);
 			} else {
-				await api.createExtension(undefined, packageStream);
+				await api.createExtension(undefined, fs.createReadStream(packagePath));
 			}
 		}
 	} catch (err: any) {
@@ -295,15 +294,8 @@ async function _publish(packagePath: string, sigzipPath: string | undefined, man
 	log.done(`Published ${description}.`);
 }
 
-async function _publishSignedPackage(api: GalleryApi, packageName: string, packageStream: fs.ReadStream, sigzipName: string, sigzipStream: fs.ReadStream, manifest: ManifestPublish) {
+async function _publishSignedPackage(api: GalleryApi, packagePath: string, sigzipPath: string, manifest: ManifestPublish) {
 	const extensionType = 'Visual Studio Code';
-	const form = createMultipartStream(
-		[
-			{ name: 'vsix', filename: packageName, stream: packageStream },
-			{ name: 'sigzip', filename: sigzipName, stream: sigzipStream },
-		],
-		'0f411892-ef48-488f-89d3-4f0546e84723'
-	);
 
 	const publishWithRetry = retry(handleWhen(err => err.message.includes('timeout')), {
 		maxAttempts: 3,
@@ -311,7 +303,17 @@ async function _publishSignedPackage(api: GalleryApi, packageName: string, packa
 	});
 
 	return await publishWithRetry.execute(async () => {
-		return await api.publishExtensionWithPublisherSignature(undefined, form, manifest.publisher, manifest.name, extensionType);
+		const form = createMultipartStream(
+			[
+				{ name: 'vsix', filename: basename(packagePath), stream: fs.createReadStream(packagePath) },
+				{ name: 'sigzip', filename: basename(sigzipPath), stream: fs.createReadStream(sigzipPath) },
+			],
+			'0f411892-ef48-488f-89d3-4f0546e84723'
+		);
+
+		return await runWithStreamError(form, () =>
+			api.publishExtensionWithPublisherSignature(undefined, form, manifest.publisher, manifest.name, extensionType)
+		);
 	});
 }
 

--- a/src/test/multipart.test.ts
+++ b/src/test/multipart.test.ts
@@ -1,0 +1,38 @@
+import * as assert from 'assert';
+import { Readable } from 'stream';
+import { createMultipartStream } from '../multipart';
+
+describe('createMultipartStream', () => {
+	it('creates a multipart stream', async () => {
+		const stream = createMultipartStream(
+			[
+				{ name: 'first', filename: 'first.bin', stream: Readable.from(['first contents']) },
+				{ name: 'second', filename: 'second.bin', stream: Readable.from(['second contents']) },
+			],
+			'boundary'
+		);
+		let contents = '';
+
+		for await (const chunk of stream) {
+			contents += chunk;
+		}
+
+		assert.strictEqual(
+			contents,
+			[
+				'--boundary',
+				'Content-Disposition: attachment; name=first; filename="first.bin"',
+				'Content-Type: application/octet-stream',
+				'',
+				'first contents',
+				'--boundary',
+				'Content-Disposition: attachment; name=second; filename="second.bin"',
+				'Content-Type: application/octet-stream',
+				'',
+				'second contents',
+				'--boundary--',
+				'',
+			].join('\r\n')
+		);
+	});
+});

--- a/src/test/multipart.test.ts
+++ b/src/test/multipart.test.ts
@@ -35,4 +35,26 @@ describe('createMultipartStream', () => {
 			].join('\r\n')
 		);
 	});
+
+	it('propagates errors emitted before a part is consumed', async () => {
+		const error = new Error('failed to read');
+		const failedStream = new Readable({ read() {} });
+		const stream = createMultipartStream(
+			[
+				{ name: 'first', filename: 'first.bin', stream: Readable.from(['first contents']) },
+				{ name: 'second', filename: 'second.bin', stream: failedStream },
+			],
+			'boundary'
+		);
+
+		failedStream.destroy(error);
+
+		await assert.rejects(
+			async () => {
+				for await (const _ of stream) {
+				}
+			},
+			actual => actual === error
+		);
+	});
 });

--- a/src/test/multipart.test.ts
+++ b/src/test/multipart.test.ts
@@ -1,64 +1,235 @@
 import * as assert from 'assert';
 import { Readable } from 'stream';
-import { createMultipartStream, runWithStreamError } from '../multipart';
+import { createMultipartStream, MultipartPart, runWithStreamError } from '../multipart';
+
+async function chunks(stream: Readable): Promise<(string | Buffer)[]> {
+	const result: (string | Buffer)[] = [];
+
+	for await (const chunk of stream) {
+		result.push(chunk);
+	}
+
+	return result;
+}
+
+async function collect(stream: Readable): Promise<Buffer> {
+	const collected = await chunks(stream);
+	return Buffer.concat(collected.map(chunk => (Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, 'utf8'))));
+}
+
+function part(name: string, filename: string, contents: string | Buffer): MultipartPart {
+	return { name, filename, stream: Readable.from([contents]) };
+}
+
+function header(boundary: string, name: string, filename: string): string {
+	return (
+		`--${boundary}\r\n` +
+		`Content-Disposition: attachment; name=${name}; filename="${filename}"\r\n` +
+		`Content-Type: application/octet-stream\r\n\r\n`
+	);
+}
 
 describe('createMultipartStream', () => {
 	it('creates a multipart stream', async () => {
 		const stream = createMultipartStream(
+			[part('first', 'first.bin', 'first contents'), part('second', 'second.bin', 'second contents')],
+			'boundary'
+		);
+
+		assert.strictEqual(
+			(await collect(stream)).toString('utf8'),
+			header('boundary', 'first', 'first.bin') +
+				'first contents\r\n' +
+				header('boundary', 'second', 'second.bin') +
+				'second contents\r\n--boundary--\r\n'
+		);
+	});
+
+	// Every emitted chunk is written to the request on its own, so this keeps the body to a few
+	// large chunks rather than one per header line.
+	it('emits one chunk per header, body chunk and part footer', async () => {
+		const stream = createMultipartStream(
 			[
-				{ name: 'first', filename: 'first.bin', stream: Readable.from(['first contents']) },
-				{ name: 'second', filename: 'second.bin', stream: Readable.from(['second contents']) },
+				{ name: 'first', filename: 'first.bin', stream: Readable.from(['one', 'two']) },
+				part('second', 'second.bin', 'second contents'),
 			],
 			'boundary'
 		);
-		let contents = '';
 
-		for await (const chunk of stream) {
-			contents += chunk;
-		}
+		assert.deepStrictEqual(await chunks(stream), [
+			header('boundary', 'first', 'first.bin'),
+			'one',
+			'two',
+			'\r\n',
+			header('boundary', 'second', 'second.bin'),
+			'second contents',
+			'\r\n',
+			'--boundary--\r\n',
+		]);
+	});
+
+	it('preserves binary contents verbatim', async () => {
+		const contents = Buffer.from([0x00, 0xff, 0x0d, 0x0a, 0x2d, 0x2d, 0x80, 0xfe]);
+		const stream = createMultipartStream([part('vsix', 'vsix.bin', contents)], 'boundary');
+
+		const expected = Buffer.concat([
+			Buffer.from(header('boundary', 'vsix', 'vsix.bin'), 'utf8'),
+			contents,
+			Buffer.from('\r\n--boundary--\r\n', 'utf8'),
+		]);
+
+		assert.ok((await collect(stream)).equals(expected));
+	});
+
+	it('handles empty contents', async () => {
+		const stream = createMultipartStream([part('vsix', 'vsix.bin', Buffer.alloc(0))], 'boundary');
 
 		assert.strictEqual(
-			contents,
-			[
-				'--boundary',
-				'Content-Disposition: attachment; name=first; filename="first.bin"',
-				'Content-Type: application/octet-stream',
-				'',
-				'first contents',
-				'--boundary',
-				'Content-Disposition: attachment; name=second; filename="second.bin"',
-				'Content-Type: application/octet-stream',
-				'',
-				'second contents',
-				'--boundary--',
-				'',
-			].join('\r\n')
+			(await collect(stream)).toString('utf8'),
+			header('boundary', 'vsix', 'vsix.bin') + '\r\n--boundary--\r\n'
 		);
+	});
+
+	it('handles no parts', async () => {
+		assert.strictEqual((await collect(createMultipartStream([], 'boundary'))).toString('utf8'), '--boundary--\r\n');
+	});
+
+	it('leaves filenames that need no escaping untouched', async () => {
+		const filename = "publisher.extension-1.0.0 (win32-x64); v1's.vsix";
+		const stream = createMultipartStream([part('vsix', filename, 'contents')], 'boundary');
+
+		assert.ok((await collect(stream)).toString('utf8').includes(`filename="${filename}"`));
+	});
+
+	it('escapes characters that would break out of the header', async () => {
+		const stream = createMultipartStream(
+			[part('vsix', 'quote".vsix', 'first'), part('sigzip', 'crlf\r\ninjected: header.zip', 'second')],
+			'boundary'
+		);
+
+		const contents = (await collect(stream)).toString('utf8');
+
+		assert.ok(contents.includes('filename="quote%22.vsix"'));
+		assert.ok(contents.includes('filename="crlf%0D%0Ainjected: header.zip"'));
+		assert.strictEqual(contents.split('\r\n').filter(line => line.startsWith('--boundary')).length, 3);
+	});
+
+	it('does not emit close once the stream ends', async () => {
+		const stream = createMultipartStream([part('vsix', 'vsix.bin', 'contents')], 'boundary');
+		let closed = false;
+
+		stream.on('close', () => (closed = true));
+		await collect(stream);
+		await new Promise(resolve => setTimeout(resolve, 10));
+
+		assert.strictEqual(closed, false);
 	});
 
 	it('propagates errors emitted before a part is consumed', async () => {
 		const error = new Error('failed to read');
 		const failedStream = new Readable({ read() {} });
 		const stream = createMultipartStream(
-			[
-				{ name: 'first', filename: 'first.bin', stream: Readable.from(['first contents']) },
-				{ name: 'second', filename: 'second.bin', stream: failedStream },
-			],
+			[part('first', 'first.bin', 'first contents'), { name: 'second', filename: 'second.bin', stream: failedStream }],
 			'boundary'
 		);
 
 		failedStream.destroy(error);
 
+		await assert.rejects(collect(stream), actual => actual === error);
+	});
+
+	it('propagates errors emitted while a part is consumed', async () => {
+		const error = new Error('failed to read');
+		const stream = createMultipartStream(
+			[
+				{
+					name: 'vsix',
+					filename: 'vsix.bin',
+					stream: Readable.from(
+						(async function* () {
+							yield 'partial contents';
+							throw error;
+						})()
+					),
+				},
+			],
+			'boundary'
+		);
+
+		await assert.rejects(collect(stream), actual => actual === error);
+	});
+
+	it('destroys every part once the stream is consumed', async () => {
+		const parts = [part('first', 'first.bin', 'first contents'), part('second', 'second.bin', 'second contents')];
+
+		await collect(createMultipartStream(parts, 'boundary'));
+
+		assert.deepStrictEqual(parts.map(p => p.stream.destroyed), [true, true]);
+	});
+
+	it('destroys parts that are never consumed because an earlier part failed', async () => {
+		const failedStream = new Readable({ read() {} });
+		const unconsumed = new Readable({ read() {} });
+		const stream = createMultipartStream(
+			[
+				{ name: 'first', filename: 'first.bin', stream: failedStream },
+				{ name: 'second', filename: 'second.bin', stream: unconsumed },
+			],
+			'boundary'
+		);
+
+		failedStream.destroy(new Error('failed to read'));
+		await assert.rejects(collect(stream));
+
+		assert.strictEqual(unconsumed.destroyed, true);
+	});
+
+	it('destroys every part when the consumer stops reading', async () => {
+		const parts = [
+			{ name: 'first', filename: 'first.bin', stream: new Readable({ read() { this.push('contents'); } }) },
+			{ name: 'second', filename: 'second.bin', stream: new Readable({ read() { this.push('contents'); } }) },
+		];
+		const stream = createMultipartStream(parts, 'boundary');
+
+		for await (const _ of stream) {
+			break;
+		}
+
+		await new Promise(resolve => setImmediate(resolve));
+		assert.deepStrictEqual(parts.map(p => p.stream.destroyed), [true, true]);
+	});
+
+	it('destroys every part when the stream is destroyed before it is read', async () => {
+		const parts = [part('first', 'first.bin', 'first contents'), part('second', 'second.bin', 'second contents')];
+		const stream = createMultipartStream(parts, 'boundary');
+
+		stream.destroy();
+
+		await new Promise(resolve => setImmediate(resolve));
+		assert.deepStrictEqual(parts.map(p => p.stream.destroyed), [true, true]);
+	});
+});
+
+describe('runWithStreamError', () => {
+	it('resolves with the result of the operation', async () => {
+		const stream = createMultipartStream([part('vsix', 'vsix.bin', 'contents')], 'boundary');
+
+		assert.strictEqual(await runWithStreamError(stream, async () => 'result'), 'result');
+	});
+
+	it('rejects with the error of the operation', async () => {
+		const error = new Error('request failed');
+		const stream = createMultipartStream([part('vsix', 'vsix.bin', 'contents')], 'boundary');
+
 		await assert.rejects(
-			async () => {
-				for await (const _ of stream) {
-				}
-			},
+			runWithStreamError(stream, async () => {
+				throw error;
+			}),
 			actual => actual === error
 		);
 	});
 
-	it('rejects an operation when the multipart stream errors', async () => {
+	it('rejects an operation that never settles when the multipart stream errors', async () => {
 		const error = new Error('failed to read');
 		const failedStream = Readable.from(
 			(async function* () {
@@ -66,17 +237,27 @@ describe('createMultipartStream', () => {
 				throw error;
 			})()
 		);
-		const stream = createMultipartStream(
-			[{ name: 'part', filename: 'part.bin', stream: failedStream }],
-			'boundary'
-		);
+		const stream = createMultipartStream([{ name: 'vsix', filename: 'vsix.bin', stream: failedStream }], 'boundary');
 
 		await assert.rejects(
-			runWithStreamError(stream, async () => {
+			runWithStreamError(stream, () => {
 				stream.resume();
-				return await new Promise<never>(() => {});
+				return new Promise<never>(() => {});
 			}),
 			actual => actual === error
 		);
+	});
+
+	it('keeps handling stream errors that arrive after the operation settles', async () => {
+		const failedStream = new Readable({ read() {} });
+		const stream = createMultipartStream([{ name: 'vsix', filename: 'vsix.bin', stream: failedStream }], 'boundary');
+
+		stream.resume();
+		assert.strictEqual(await runWithStreamError(stream, async () => 'result'), 'result');
+
+		// Without a listener this would be an unhandled 'error' event, which terminates the process.
+		assert.ok(stream.listenerCount('error') > 0);
+		failedStream.destroy(new Error('failed to read'));
+		await new Promise(resolve => setTimeout(resolve, 10));
 	});
 });

--- a/src/test/multipart.test.ts
+++ b/src/test/multipart.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { Readable } from 'stream';
-import { createMultipartStream } from '../multipart';
+import { createMultipartStream, runWithStreamError } from '../multipart';
 
 describe('createMultipartStream', () => {
 	it('creates a multipart stream', async () => {
@@ -54,6 +54,28 @@ describe('createMultipartStream', () => {
 				for await (const _ of stream) {
 				}
 			},
+			actual => actual === error
+		);
+	});
+
+	it('rejects an operation when the multipart stream errors', async () => {
+		const error = new Error('failed to read');
+		const failedStream = Readable.from(
+			(async function* () {
+				yield 'partial contents';
+				throw error;
+			})()
+		);
+		const stream = createMultipartStream(
+			[{ name: 'part', filename: 'part.bin', stream: failedStream }],
+			'boundary'
+		);
+
+		await assert.rejects(
+			runWithStreamError(stream, async () => {
+				stream.resume();
+				return await new Promise<never>(() => {});
+			}),
 			actual => actual === error
 		);
 	});


### PR DESCRIPTION
This can be replaced with a bit of code in the repo, deleting 8 prod deps.

I though it would be more but no, headers were already being manually constructed, so it's all just boilerplate with Node's streaming. There's more "handle errors in streams" code than actual form code, and then way more testing than actual form and error code.