### PR TITLE
Fix MSAL declaration build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
+
+      - name: Build
+        run: npm run build
       
       - name: Run tests
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
-
-      - name: Build
-        run: npm run build
       
       - name: Run tests
         run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,9 +207,9 @@
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "16.13.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.13.0.tgz",
-            "integrity": "sha512-rOAy0KUcyBbdwVJ+f3uPpthXatFLLZN+/KWAsTLzk1aB23Xl9DRmmXYwSvBFOZyXj4jUQQ5FKxxRkhAFW1fOow==",
+            "version": "16.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.14.0.tgz",
+            "integrity": "sha512-A4rb55hI86Q9tBl/+jBj7TMz7iX2RFgQs/nExFzcAtoI/BFRVdaH5SL/MivrYD7qvweMpN8AgVvVMHV8UBYxew==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
 	},
 	"overrides": {
 		"serialize-javascript": "7.x",
-		"diff": "^9.0.0"
+		"diff": "^9.0.0",
+		"@azure/msal-common": "16.14.0"
 	}
 }


### PR DESCRIPTION
## Summary

- override `@azure/msal-common` to 16.14.0, which removes the broken DOM type dependency from its public declarations

## Validation

- `npm ci`
- `npm run build`