### PR TITLE
package: respect repository directory in README links

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -101,7 +101,7 @@ export interface ManifestPackage {
 	contributors?: string | Person[];
 	main?: string;
 	browser?: string;
-	repository?: string | { type?: string; url?: string };
+	repository?: string | { type?: string; url?: string; directory?: string };
 	scripts?: { [name: string]: string };
 	dependencies?: { [name: string]: string };
 	devDependencies?: { [name: string]: string };

--- a/src/package.ts
+++ b/src/package.ts
@@ -966,11 +966,16 @@ export abstract class MarkdownProcessor extends BaseProcessor {
 		githostBranch: string | undefined
 	): { content: string; images: string; repository: string } | undefined {
 		let repository = null;
+		let directory: string | undefined;
 
 		if (typeof this.manifest.repository === 'string') {
 			repository = this.manifest.repository;
 		} else if (this.manifest.repository && typeof this.manifest.repository['url'] === 'string') {
 			repository = this.manifest.repository['url'];
+			directory =
+				typeof this.manifest.repository['directory'] === 'string'
+					? this.manifest.repository['directory']
+					: undefined;
 		}
 
 		if (!repository) {
@@ -991,15 +996,19 @@ export abstract class MarkdownProcessor extends BaseProcessor {
 		const branchName = githostBranch ? githostBranch : 'HEAD';
 
 		if (/^github/.test(match.groups.domain)) {
+			const content = `https://github.com/${project}/blob/${branchName}`;
+			const images = `https://github.com/${project}/raw/${branchName}`;
 			return {
-				content: `https://github.com/${project}/blob/${branchName}`,
-				images: `https://github.com/${project}/raw/${branchName}`,
+				content: directory ? urljoin(content, directory) : content,
+				images: directory ? urljoin(images, directory) : images,
 				repository: `https://github.com/${project}`,
 			};
 		} else if (/^gitlab/.test(match.groups.domain)) {
+			const content = `https://gitlab.com/${project}/-/blob/${branchName}`;
+			const images = `https://gitlab.com/${project}/-/raw/${branchName}`;
 			return {
-				content: `https://gitlab.com/${project}/-/blob/${branchName}`,
-				images: `https://gitlab.com/${project}/-/raw/${branchName}`,
+				content: directory ? urljoin(content, directory) : content,
+				images: directory ? urljoin(images, directory) : images,
 				repository: `https://gitlab.com/${project}`,
 			};
 		}

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -2601,6 +2601,35 @@ describe('MarkdownProcessor', () => {
 			});
 	});
 
+	it('should include the repository directory in inferred GitHub URLs', async () => {
+		const manifest = {
+			name: 'test',
+			publisher: 'mocha',
+			version: '0.0.1',
+			description: 'test extension',
+			engines: Object.create(null),
+			repository: {
+				url: 'https://github.com/username/repository',
+				directory: 'extensions/test',
+			},
+		};
+
+		const processor = new ReadmeProcessor(manifest, { githubBranch: 'main' });
+		const readme = {
+			path: 'extension/readme.md',
+			contents: '[Documentation](docs.md)\n\n![Demo](images/demo.gif)\n\nFixes #123',
+		};
+
+		const actual = await read(await processor.onFile(readme));
+
+		assert.strictEqual(
+			actual,
+			'[Documentation](https://github.com/username/repository/blob/main/extensions/test/docs.md)\n\n' +
+				'![Demo](https://github.com/username/repository/raw/main/extensions/test/images/demo.gif)\n\n' +
+				'Fixes [#123](https://github.com/username/repository/issues/123)'
+		);
+	});
+
 	it('should override image URLs with baseImagesUrl while also respecting githubBranch', () => {
 		const manifest = {
 			name: 'test',


### PR DESCRIPTION
## Summary
- include the package.json repository.directory path when inferring GitHub and GitLab README link bases
- keep expanded issue references pointed at the repository root
- add regression coverage for content links and images in monorepo extensions

Fixes #1208

## Validation
- `npm run compile`
- `npm run api`
- `npm test -- --grep MarkdownProcessor`
- `npm test` (308 passing, 3 pending; 2 Git-spawning tests failed from malformed inherited `GIT_CONFIG_*` variables)
- reran both Git-spawning failures after removing the malformed inherited variables (2 passing)