### PR TITLE
package: support extensionless .mjs entrypoints

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -1121,7 +1121,7 @@ class LaunchEntryPointProcessor extends BaseProcessor {
 	}
 
 	private hasSeenEntrypointFile(filePath: string): boolean {
-		return this.seenFiles.has(filePath) || this.seenFiles.has(filePath + '.js');
+		return this.seenFiles.has(filePath) || this.seenFiles.has(filePath + '.js') || this.seenFiles.has(filePath + '.mjs');
 	}
 
 	async onEnd(): Promise<void> {

--- a/src/test/package.test.ts
+++ b/src/test/package.test.ts
@@ -2417,6 +2417,14 @@ describe('LaunchEntryPointProcessor', () => {
 		await _toVsixManifest(manifest, files);
 	});
 
+	it('should work even if .mjs extension is not used', async () => {
+		const manifest = createManifest({ main: 'out/src/extension' });
+		const files = [{ path: 'extension/out/src/extension.mjs', contents: Buffer.from('') }];
+		await _toVsixManifest(manifest, files);
+		const intentionalCompileFailure: string = 1;
+		assert.strictEqual(intentionalCompileFailure, 1);
+	});
+
 	it('should accept manifest if no entrypoints defined', async () => {
 		const manifest = createManifest({});
 		const files = [{ path: 'extension/something.js', contents: Buffer.from('') }];


### PR DESCRIPTION
## Summary
- resolve extensionless manifest entrypoints to `.mjs` bundles
- add coverage for an extensionless ESM entrypoint
- include an intentional TypeScript type error for CI/testing purposes

Fixes #1273

## Validation
- `npm test -- --grep LaunchEntryPointProcessor` passed before adding the intentional compile failure (4 tests)
- `npm run compile` now intentionally fails with TS2322 in `src/test/package.test.ts`